### PR TITLE
FieldValue component

### DIFF
--- a/src/forms/FieldValue.scss
+++ b/src/forms/FieldValue.scss
@@ -8,20 +8,21 @@
 
   /* Owl selector for flow margins */
   > * + * {
-    margin-block-start: var(--bloom-spacer-label);
+    margin-block-start: var(--bloom-spacer-text);
   }
 
   > [data-part="label"] {
     color: var(--bloom-input-text-label-color);
     font-size: var(--bloom-type-label);
+    margin-block-end: var(--bloom-spacer-label);
   }
 
   > [data-part="value"] {
     color: var(--bloom-input-text-highlight-color);
   }
 
-  > [data-part="helper-text"] {
-    color: var(--bloom-input-text-label-color);
+  > [data-part="help-text"] {
+    color: var(--bloom-input-text-placeholder-color);
     font-size: var(--bloom-type-label);
   }
 }

--- a/src/forms/FieldValue.scss
+++ b/src/forms/FieldValue.scss
@@ -1,0 +1,27 @@
+.field-value {
+  font-family: var(--bloom-font-alt-sans);
+
+  /* Reset child margins */
+  > * {
+    margin: 0;
+  }
+
+  /* Owl selector for flow margins */
+  > * + * {
+    margin-block-start: var(--bloom-spacer-label);
+  }
+
+  > [data-part="label"] {
+    color: var(--bloom-input-text-label-color);
+    font-size: var(--bloom-type-label);
+  }
+
+  > [data-part="value"] {
+    color: var(--bloom-input-text-highlight-color);
+  }
+
+  > [data-part="helper-text"] {
+    color: var(--bloom-input-text-label-color);
+    font-size: var(--bloom-type-label);
+  }
+}

--- a/src/forms/FieldValue.tsx
+++ b/src/forms/FieldValue.tsx
@@ -5,8 +5,10 @@ import "./FieldValue.scss"
 export interface FieldValueProps {
   /** Value content */
   children: React.ReactNode
-  label: string
-  helperText?: string
+  /** Label content */
+  label?: string
+  /** Additional help text below the content */
+  helpText?: string
 }
 
 const FieldValue = (props: FieldValueProps) => {
@@ -14,7 +16,7 @@ const FieldValue = (props: FieldValueProps) => {
     <div className="field-value" role="gridcell">
       {props.label && <p data-part="label">{props.label}</p>}
       <p data-part="value">{props.children}</p>
-      {props.helperText && <p data-part="helper-text">{props.helperText}</p>}
+      {props.helpText && <p data-part="help-text">{props.helpText}</p>}
     </div>
   )
 }

--- a/src/forms/FieldValue.tsx
+++ b/src/forms/FieldValue.tsx
@@ -9,11 +9,18 @@ export interface FieldValueProps {
   label?: string
   /** Additional help text below the content */
   helpText?: string
+  /** Element ID */
+  id?: string
+  /** Additional CSS classes */
+  className?: string
 }
 
 const FieldValue = (props: FieldValueProps) => {
+  const classNames = ["field-value"]
+  if (props.className) classNames.push(props.className)
+
   return (
-    <div className="field-value" role="gridcell">
+    <div id={props.id} className={classNames.join(" ")} role="gridcell">
       {props.label && <p data-part="label">{props.label}</p>}
       <p data-part="value">{props.children}</p>
       {props.helpText && <p data-part="help-text">{props.helpText}</p>}

--- a/src/forms/FieldValue.tsx
+++ b/src/forms/FieldValue.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+import "./FieldValue.scss"
+
+export interface FieldValueProps {
+  /** Value content */
+  children: React.ReactNode
+  label: string
+  helperText?: string
+}
+
+const FieldValue = (props: FieldValueProps) => {
+  return (
+    <div className="field-value" role="gridcell">
+      {props.label && <p data-part="label">{props.label}</p>}
+      <p data-part="value">{props.children}</p>
+      {props.helperText && <p data-part="helper-text">{props.helperText}</p>}
+    </div>
+  )
+}
+
+export default FieldValue

--- a/src/forms/__stories_/FieldValue.docs.mdx
+++ b/src/forms/__stories_/FieldValue.docs.mdx
@@ -1,0 +1,12 @@
+import { ArgsTable } from "@storybook/addon-docs"
+import FieldValue from "../FormErrorMessage"
+
+# &lt;FieldValue /&gt;
+
+## Properties
+
+<ArgsTable of={FieldValue} />
+
+## Theme Variables
+
+The `FieldValue` component utilizes various input text and spacer tokens from the global design system.

--- a/src/forms/__stories_/FieldValue.stories.tsx
+++ b/src/forms/__stories_/FieldValue.stories.tsx
@@ -2,9 +2,20 @@ import React from "react"
 import { Story } from "@storybook/react"
 import FieldValue from "../FieldValue"
 
+import MDXDocs from "./FieldValue.docs.mdx"
+
 export default {
   title: "Forms/FieldValue",
   component: FieldValue,
+  parameters: {
+    docs: {
+      page: MDXDocs,
+    },
+  },
 }
 
-export const withHelperText = () => <FieldValue label="Property Amenities" helperText="All good stuff">Pool, BBQ, Rooftop View</FieldValue>
+export const standalone = () => <FieldValue>Pool, BBQ, Rooftop View</FieldValue>
+
+export const withLabel = () => <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+
+export const withHelperText = () => <FieldValue label="Property Amenities" helpText="All good stuff">Pool, BBQ, Rooftop View</FieldValue>

--- a/src/forms/__stories_/FieldValue.stories.tsx
+++ b/src/forms/__stories_/FieldValue.stories.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { Story } from "@storybook/react"
+import FieldValue from "../FieldValue"
+
+export default {
+  title: "Forms/FieldValue",
+  component: FieldValue,
+}
+
+export const withHelperText = () => <FieldValue label="Property Amenities" helperText="All good stuff">Pool, BBQ, Rooftop View</FieldValue>

--- a/src/forms/__stories_/FieldValue.stories.tsx
+++ b/src/forms/__stories_/FieldValue.stories.tsx
@@ -16,6 +16,12 @@ export default {
 
 export const standalone = () => <FieldValue>Pool, BBQ, Rooftop View</FieldValue>
 
-export const withLabel = () => <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+export const withLabel = () => (
+  <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+)
 
-export const withHelperText = () => <FieldValue label="Property Amenities" helpText="All good stuff">Pool, BBQ, Rooftop View</FieldValue>
+export const withHelperText = () => (
+  <FieldValue label="Property Amenities" helpText="All good stuff">
+    Pool, BBQ, Rooftop View
+  </FieldValue>
+)

--- a/src/forms/__tests__/FieldValue.test.tsx
+++ b/src/forms/__tests__/FieldValue.test.tsx
@@ -1,0 +1,22 @@
+import { render, cleanup } from "@testing-library/react"
+import FieldValue from "../FieldValue"
+
+afterEach(cleanup)
+
+describe("<FieldValue>", () => {
+  it("displays the field value", () => {
+    const content = "Value content"
+    const label = "Label text"
+    const helpText = "Help text"
+    const { getByText, container } = render(
+      <FieldValue id="fv" className="test-class" label={label} helpText={helpText}>
+        {content}
+      </FieldValue>
+    )
+    expect(getByText(content)).toBeInTheDocument()
+    expect(getByText(label)).toBeInTheDocument()
+    expect(getByText(helpText)).toBeInTheDocument()
+    expect(container.querySelector("#fv")).not.toBeNull()
+    expect(container.querySelector("#fv.test-class")).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Addresses #6

A couple of observations:

Because we're using semantic text tokens from the design system, I didn't add any FieldValue-specific theme variables, because I imagine we'd just want FieldValue to pick up any global overrides of the semantic tokens if present. But let me know if we should revisit that.

Continuing in the `data-*` vein, I took a conceptual page from the world of web components/shadow parts, and styled the subcomponents using `data-part` rather than something BEM-ish like `field-value__label`, `field-value__value`, etc. Let me know what you think of that sort of approach, rather than using class names.