### PR TITLE
feat: `Heading` and `HeadingGroup` components

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,7 @@
 export * from "./src/expandableText/ExpandableText"
 
+export { default as FieldValue } from "./src/forms/FieldValue"
 export { default as FormErrorMessage } from "./src/forms/FormErrorMessage"
+export { default as Icon } from "./src/icons/Icon"
+export { default as Heading } from "./src/text/Heading"
+export { default as HeadingGroup } from "./src/text/HeadingGroup"

--- a/src/global/app-css.scss
+++ b/src/global/app-css.scss
@@ -18,7 +18,9 @@ html {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
 }
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
 }
 
@@ -27,11 +29,20 @@ body {
   padding: 0;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   overflow-wrap: break-word;
 }
 
-p, ul, ol, blockquote, figure {
+p,
+ul,
+ol,
+blockquote,
+figure {
   overflow-wrap: break-word;
 }
 
@@ -67,3 +78,5 @@ body {
   color: var(--bloom-color-on-surface);
   line-height: inherit;
 }
+
+@import "text.scss";

--- a/src/global/text.scss
+++ b/src/global/text.scss
@@ -1,0 +1,85 @@
+/**
+ * Typography
+ */
+
+.text-heading-1,
+.text-heading-2,
+.text-heading-3,
+.text-heading-4,
+.text-subheading,
+.text-strong,
+.text-label,
+.text-small {
+  margin-block: 0;
+}
+
+.text-heading-1,
+.text-heading-2,
+.text-heading-3 {
+  font-family: var(--bloom-font-serif);
+  font-weight: normal;
+  line-height: var(--bloom-line-height-heading);
+}
+
+.text-heading-1 {
+  font-size: var(--bloom-type-heading-1);
+}
+
+.text-heading-2 {
+  font-size: var(--bloom-type-heading-2);
+}
+
+.text-heading-3 {
+  font-size: var(--bloom-type-heading-3);
+}
+
+.text-heading-4,
+.text-subheading,
+.text-strong,
+.text-label,
+.text-small {
+  font-family: var(--bloom-font-alt-sans);
+  font-weight: var(--bloom-font-weight-semibold);
+}
+
+.text-heading-4 {
+  font-size: var(--bloom-type-heading-4);
+  line-height: var(--bloom-line-height-heading);
+}
+
+.text-subheading {
+  font-size: var(--bloom-type-subheading);
+  line-height: var(--bloom-line-height-heading);
+}
+
+.text-strong,
+.text-label,
+.text-small {
+  line-height: var(--bloom-line-height-content);
+}
+
+.text-strong {
+  font-size: var(--bloom-type-body);
+}
+
+.text-label {
+  font-size: var(--bloom-type-label);
+}
+
+.text-small {
+  font-size: var(--bloom-type-caption);
+}
+
+@media (max-width: 640px) {
+  .text-heading-1 {
+    font-size: var(--bloom-type-heading-2);
+  }
+  
+  .text-heading-2 {
+    font-size: var(--bloom-type-heading-3);
+  }
+  
+  .text-heading-3 {
+    font-size: var(--bloom-type-heading-4);
+  }
+}

--- a/src/text/Heading.tsx
+++ b/src/text/Heading.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+
+export interface HeadingProps {
+  /** Heading text */
+  children: React.ReactNode
+  /** Typography style of the heading */
+  typography?: "heading-1" | "heading-2" | "heading-3" | "heading-4" | "subheading" | "strong" | "label" | "small"
+  /** Heading level (`h1` through `h4`) */
+  priority?: 1 | 2 | 3 |4
+  /** Element ID */
+  id?: string
+  /** Additional CSS classes */
+  className?: string
+}
+
+const Heading = (props: HeadingProps) => {
+  const priority = props.priority && props.priority >= 1 && props.priority <= 4 ? props.priority : 1
+  const typography = props.typography || "heading-1"
+  const HnTag = `h${priority}` as keyof JSX.IntrinsicElements
+
+  const classNames = [`text-${typography}`]
+  if (props.className) classNames.push(props.className)
+
+  return <HnTag id={props.id} className={classNames.join(" ")}>{props.children}</HnTag>
+}
+
+export default Heading

--- a/src/text/HeadingGroup.scss
+++ b/src/text/HeadingGroup.scss
@@ -1,0 +1,23 @@
+.heading-group {
+  --heading-margin: 0rem;
+  --subheading-margin: var(--bloom-s4);
+  --heading-color: inherit;
+  --subheading-color: inherit;
+  --subheading-font-size: var(--bloom-font-size-base);
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-block: var(--heading-margin);
+    color: var(--heading-color);
+  }
+
+  p {
+    margin-block: var(--subheading-margin);
+    font-size: var(--subheading-font-size);
+    color: var(--subheading-color);
+  }
+}

--- a/src/text/HeadingGroup.tsx
+++ b/src/text/HeadingGroup.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import Heading, { HeadingProps } from "./Heading"
+import "./HeadingGroup.scss"
+
+export interface HeadingGroupProps extends Pick<HeadingProps, "typography"> {
+  /** A string or element to display in an `h2` tag (overridable via `headingPriority`) */
+  heading: React.ReactNode
+  /** A string or element to display in a `p` tag */
+  subheading: React.ReactNode
+  /**
+   * The heading level (1 through 4)
+   * @default 2
+   */
+  headingPriority?: 1 | 2 | 3 |4
+  /** Additional class name for the whole group */
+  className?: string
+}
+
+const HeadingGroup = (props: HeadingGroupProps) => {
+  const classNames = ["heading-group"]
+  if (props.className) classNames.push(props.className)
+
+  return (
+    <hgroup className={classNames.join(" ")} role="group">
+      <Heading priority={props.headingPriority ?? 2} typography={props.typography || "heading-2"}>{props.heading}</Heading>
+      <p>{props.subheading}</p>
+    </hgroup>
+  )
+}
+
+export default HeadingGroup

--- a/src/text/HeadingGroup.tsx
+++ b/src/text/HeadingGroup.tsx
@@ -12,6 +12,8 @@ export interface HeadingGroupProps extends Pick<HeadingProps, "typography"> {
    * @default 2
    */
   headingPriority?: 1 | 2 | 3 |4
+  /** Element ID */
+  id?: string
   /** Additional class name for the whole group */
   className?: string
 }
@@ -21,7 +23,7 @@ const HeadingGroup = (props: HeadingGroupProps) => {
   if (props.className) classNames.push(props.className)
 
   return (
-    <hgroup className={classNames.join(" ")} role="group">
+    <hgroup id={props.id} className={classNames.join(" ")} role="group">
       <Heading priority={props.headingPriority ?? 2} typography={props.typography || "heading-2"}>{props.heading}</Heading>
       <p>{props.subheading}</p>
     </hgroup>

--- a/src/text/__stories__/Heading.docs.mdx
+++ b/src/text/__stories__/Heading.docs.mdx
@@ -1,0 +1,30 @@
+import { ArgsTable } from "@storybook/addon-docs"
+import { Link } from "../../../documentation/components/Link"
+
+import Heading from "../Heading"
+
+# &lt;Heading /&gt;
+
+## Properties
+
+<ArgsTable of={Heading} />
+
+## Theme Variables
+
+The heading typography styles are provided by global text utilities:  
+`text-heading-1`, `text-heading-2`, `text-heading-3`, `text-heading-4`, `text-subheading`, `text-strong`, `text-label`, `text-small`. These utilities in turn utilize global type tokens. In addition to the <Link href="/?path=/docs/tokens-typography-tokens--page">ones listed here</Link>, they are:
+
+| Name                                | Description                                                      | Default                              |
+| ----------------------------------- | ---------------------------------------------------------------- | ------------------------------------ |
+| `--bloom-line-height-heading`        | Line height                            | `--bloom-line-height-tight`               |
+| `--bloom-line-height-content`        | Line height                            | `--bloom-line-height-normal`               |
+| `--bloom-type-heading-1`        | Font size                           | `--bloom-font-size-4xl`               |
+| `--bloom-type-heading-2`        | Font size                           | `--bloom-font-size-3xl`               |
+| `--bloom-type-heading-3`        | Font size                           | `--bloom-font-size-2xl`               |
+| `--bloom-type-heading-4`        | Font size                           | `--bloom-font-size-xl`               |
+| `--bloom-type-subheading`        | Font size                           | `--bloom-font-size-lg`               |
+| `--bloom-type-body`        | Font size                           | `--bloom-font-size-base`               |
+| `--bloom-type-label`        | Font size                           | `--bloom-font-size-sm`               |
+| `--bloom-type-caption`        | Font size                           | `--bloom-font-size-xs`               |
+
+Note that on a mobile screen size (640px and below), the heading 1-3 utiliies are stepped down to use heading 2-4 font sizes.

--- a/src/text/__stories__/Heading.stories.tsx
+++ b/src/text/__stories__/Heading.stories.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { Story } from "@storybook/react"
+
+import Heading from "../Heading"
+
+import MDXDocs from "./Heading.docs.mdx"
+
+export default {
+  title: "Text/Heading",
+  component: Heading,
+  parameters: {
+    docs: {
+      page: MDXDocs,
+    },
+  },
+}
+
+export const heading = () => <Heading>This is a heading</Heading>
+
+export const headings = () => (
+  <div style={{display: "grid", gap: "1rem"}}>
+    <Heading typography="heading-1">Heading 1</Heading>
+    <Heading typography="heading-2">Heading 2</Heading>
+    <Heading typography="heading-3" priority={2}>Heading 3</Heading>
+    <Heading typography="heading-4" priority={3}>Heading 4</Heading>
+    <Heading typography="subheading" priority={4}>Subheading</Heading>
+    <Heading typography="strong" priority={4}>Strong</Heading>
+    <Heading typography="label" priority={4}>Label</Heading>
+    <Heading typography="small" priority={4}>Small</Heading>
+  </div>
+)

--- a/src/text/__stories__/HeadingGroup.docs.mdx
+++ b/src/text/__stories__/HeadingGroup.docs.mdx
@@ -1,0 +1,19 @@
+import { ArgsTable } from "@storybook/addon-docs"
+
+import HeadingGroup from "../HeadingGroup"
+
+# &lt;HeadingGroup /&gt;
+
+## Properties
+
+<ArgsTable of={HeadingGroup} />
+
+## Theme Variables
+
+| Name                     | Description                                         | Default                  |
+| ------------------------ | --------------------------------------------------- | ------------------------ |
+| `--heading-margin`       | Vertical space added around the top heading, if any | `0rem`                   |
+| `--subheading-margin`    | The space between the heading and subheading        | `--bloom-s4`             |
+| `--heading-color`        | The heading text color                              | `inherit`                |
+| `--subheading-color`     | The subheading text color                           | `inherit`                |
+| `--subheading-font-size` | The subheading font size                            | `--bloom-font-size-base` |

--- a/src/text/__stories__/HeadingGroup.stories.tsx
+++ b/src/text/__stories__/HeadingGroup.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { Story } from "@storybook/react"
+
+import HeadingGroup from "../HeadingGroup"
+
+import MDXDocs from "./HeadingGroup.docs.mdx"
+
+export default {
+  title: "Text/Heading Group",
+  component: HeadingGroup,
+  parameters: {
+    docs: {
+      page: MDXDocs,
+    },
+  },
+}
+
+export const headingGroup = () => <HeadingGroup heading="Poppy" subheading="The tiny, kidney-shaped seeds have been harvested from dried seed pods by various civilizations for thousands of years." />
+
+export const headingGroups = () => (
+  <div style={{display: "grid", gap: "var(--bloom-s6)"}}>
+    <HeadingGroup typography="heading-2" heading="Poppy" subheading="The tiny, kidney-shaped seeds have been harvested from dried seed pods by various civilizations for thousands of years." />
+    <HeadingGroup typography="heading-3" heading="Sunflower" subheading="For commercial purposes, sunflower seeds are usually classified by the pattern on their husks." />
+    <HeadingGroup typography="heading-4" heading="Pumpkin" subheading="Some  pumpkin cultivars are huskless, and are grown only for their edible seed." />
+  </div>
+)

--- a/src/text/__tests__/Heading.test.tsx
+++ b/src/text/__tests__/Heading.test.tsx
@@ -1,0 +1,30 @@
+import { render, cleanup } from "@testing-library/react"
+import Heading from "../Heading"
+
+afterEach(cleanup)
+
+describe("<Heading>", () => {
+  it("displays the heading", () => {
+    const content = "Heading text here"
+    const { getByText, container } = render(<Heading id="test-head" className="test-class">{content}</Heading>)
+    expect(getByText(content)).toBeInTheDocument()
+    expect(container.querySelector("h1")).not.toBeNull()
+    expect(container.querySelector("#test-head")).not.toBeNull()
+    expect(container.querySelector("#test-head.test-class")).not.toBeNull()
+  })
+
+  it("supports h2 tags", () => {
+    const { getByText, container } = render(<Heading priority={2}>h2</Heading>)
+    expect(container.querySelector("h2")).not.toBeNull()
+  })
+
+  it("supports h3 tags", () => {
+    const { getByText, container } = render(<Heading priority={3}>h3</Heading>)
+    expect(container.querySelector("h3")).not.toBeNull()
+  })
+
+  it("supports h4 tags", () => {
+    const { getByText, container } = render(<Heading priority={4}>4</Heading>)
+    expect(container.querySelector("h4")).not.toBeNull()
+  })
+})

--- a/src/text/__tests__/HeadingGroup.test.tsx
+++ b/src/text/__tests__/HeadingGroup.test.tsx
@@ -1,0 +1,16 @@
+import { render, cleanup } from "@testing-library/react"
+import HeadingGroup from "../HeadingGroup"
+
+afterEach(cleanup)
+
+describe("<HeadingGroup>", () => {
+  it("displays the heading group", () => {
+    const { getByText, container } = render(<HeadingGroup id="test-head" className="test-class" heading="Title" subheading="Subtitle" />)
+    expect(getByText("Title")).toBeInTheDocument()
+    expect(getByText("Subtitle")).toBeInTheDocument()
+    expect(container.querySelector("h2")).not.toBeNull()
+    expect(container.querySelector("p")).not.toBeNull()
+    expect(container.querySelector("#test-head")).not.toBeNull()
+    expect(container.querySelector("#test-head.test-class")).not.toBeNull()
+  })
+})


### PR DESCRIPTION
This PR addresses #16 and #8

## Description

The `Heading` and `HeadingGroup` components have been added to the design library.

## How Can This Be Tested/Reviewed?

Storybook examples here:
and here:

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described