### PR TITLE
chore: update Card spacings and use HeadingGroup in stories

### DIFF
--- a/src/blocks/Card.scss
+++ b/src/blocks/Card.scss
@@ -1,11 +1,11 @@
 .card {
   /* Component Variables */
-  --card-spacing-base: var(--bloom-s6);
   --card-spacing-sm: var(--bloom-s4);
-  --card-spacing-md: var(--bloom-s8);
-  --card-spacing-lg: var(--bloom-s12); 
+  --card-spacing-md: var(--bloom-s6);
+  --card-spacing-lg: var(--bloom-s8);
+  --card-spacing-xl: var(--bloom-s12); 
 
-  --card-spacing: var(--card-spacing-base);
+  --card-spacing: var(--card-spacing-md);
 
   --card-background-color: var(--bloom-color-white);
   --card-border-radius: var(--bloom-rounded-lg);
@@ -54,6 +54,10 @@
     --card-spacing: var(--card-spacing-lg);
   }
 
+  &[data-spacing="xl"] {
+    --card-spacing: var(--card-spacing-xl);
+  }
+
   &[data-spacing="none"] {
     --card-spacing: 0rem;
   }
@@ -62,6 +66,11 @@
 .card-header {
   padding-block-start: var(--card-header-padding-block);
   padding-inline: var(--card-header-padding-inline);
+
+  /* Solves extra HeadingGroup paragraph spacing */
+  p:last-child {
+    margin-block-end: 0;
+  }
 
   &[data-divider="flush"] {
     padding-block-end: var(--card-header-padding-block);

--- a/src/blocks/Card.tsx
+++ b/src/blocks/Card.tsx
@@ -68,7 +68,7 @@ export interface CardProps {
   /** Control spacing around card elements
    * @default base
    */
-  spacing?: "sm" | "base" | "md" | "lg" | "none"
+  spacing?: "sm" | "md" | "lg" | "xl" | "none"
   /** Element ID */
   id?: string
   /** Additional class name */

--- a/src/blocks/__stories__/Card.docs.mdx
+++ b/src/blocks/__stories__/Card.docs.mdx
@@ -24,10 +24,10 @@ import { Swatch } from "../../../documentation/components/Swatch.tsx"
 
 | Name                                    | Description                                                          | Default                   |
 | --------------------------------------- | -------------------------------------------------------------------- | ------------------------- |
-| `--card-spacing-base`                   | Default spacing around card elements                                 | `--bloom-s6`              |
 | `--card-spacing-sm`                     | Small card spacing                                                   | `--bloom-s4`              |
-| `--card-spacing-md`                     | Medium card spacing                                                  | `--bloom-s8`              |
-| `--card-spacing-lg`                     | Large card spacing                                                   | `--bloom-s12`             |
+| `--card-spacing-md`                   | Medium card spacing (default)                                 | `--bloom-s6`              |
+| `--card-spacing-lg`                     | Large card spacing                                                  | `--bloom-s8`              |
+| `--card-spacing-xl`                     | Extra Large card spacing                                                   | `--bloom-s12`             |
 | `--card-background-color`               | Background of the card                                               | `--bloom-color-white`     |
 | `--card-border-radius`                  | Card corner radius                                                   | `--bloom-rounded-lg`      |
 | `--card-border-width`                   | Border width                                                         | `--bloom-border-1`        |

--- a/src/blocks/__stories__/Card.stories.tsx
+++ b/src/blocks/__stories__/Card.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Card from "../Card"
+import HeadingGroup from "../../text/HeadingGroup"
 
 import MDXDocs from "./Card.docs.mdx"
 
@@ -13,14 +14,11 @@ export default {
   },
 }
 
-const sharedStyles =
-  ".test-card-header h3 { font-family: var(--bloom-font-serif); font-weight: normal; font-size: var(--bloom-font-size-2xl); line-height: var(--bloom-line-height-heading);"
-
 export const TextContent = () => (
   <div style={{ maxWidth: "500px" }}>
     <Card>
       <Card.Header className="test-card-header">
-        <h3>Wildflower</h3>
+        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)"  />
       </Card.Header>
 
       <Card.Section>
@@ -39,8 +37,6 @@ export const TextContent = () => (
         </p>
       </Card.Section>
     </Card>
-
-    <style>{sharedStyles}</style>
   </div>
 )
 
@@ -48,7 +44,7 @@ export const FlushDividers = () => (
   <div style={{ maxWidth: "500px" }}>
     <Card>
       <Card.Header divider="flush" className="test-card-header">
-        <h3>Wildflower</h3>
+        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)"  />
       </Card.Header>
 
       <Card.Section divider="flush">
@@ -67,8 +63,6 @@ export const FlushDividers = () => (
         </p>
       </Card.Section>
     </Card>
-
-    <style>{sharedStyles}</style>
   </div>
 )
 
@@ -76,7 +70,7 @@ export const InsetDividers = () => (
   <div style={{ maxWidth: "500px" }}>
     <Card>
       <Card.Header className="test-card-header" divider="inset">
-        <h3>Wildflower</h3>
+        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)"  />
       </Card.Header>
 
       <Card.Section divider="inset">
@@ -95,8 +89,6 @@ export const InsetDividers = () => (
         </p>
       </Card.Section>
     </Card>
-
-    <style>{sharedStyles}</style>
   </div>
 )
 
@@ -104,7 +96,7 @@ export const WithFooter = () => (
   <div style={{ maxWidth: "500px" }}>
     <Card>
       <Card.Header className="test-card-header">
-        <h3>Wildflower</h3>
+        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)"  />
       </Card.Header>
 
       <Card.Section>
@@ -138,7 +130,6 @@ export const WithFooter = () => (
     <style>
       {"#test-card-footer { --card-footer-background-color: var(--bloom-color-primary-lighter) }"}
     </style>
-    <style>{sharedStyles}</style>
   </div>
 )
 
@@ -146,9 +137,10 @@ export const Spacings = () => (
   <div style={{ maxWidth: "500px", display: "grid", gap: "2rem" }}>
     <Card spacing="none">
       <Card.Header className="test-card-header">
-        <h3>"None" Spacing</h3>
+        <HeadingGroup size="2xl" heading="none" subheading="No Spacing"  />
       </Card.Header>
 
+      <br/>
       <Card.Section>
         <p>
           The term can refer to the flowering plant as a whole, even when not in bloom, and not just
@@ -159,20 +151,7 @@ export const Spacings = () => (
 
     <Card spacing="sm">
       <Card.Header className="test-card-header">
-        <h3>Small Spacing</h3>
-      </Card.Header>
-
-      <Card.Section>
-        <p>
-          The term can refer to the flowering plant as a whole, even when not in bloom, and not just
-          the flower.
-        </p>
-      </Card.Section>
-    </Card>
-
-    <Card spacing="base">
-      <Card.Header className="test-card-header">
-        <h3>Default (Base) Spacing</h3>
+        <HeadingGroup size="2xl" heading="sm" subheading="Small Spacing"  />
       </Card.Header>
 
       <Card.Section>
@@ -185,7 +164,7 @@ export const Spacings = () => (
 
     <Card spacing="md">
       <Card.Header className="test-card-header">
-        <h3>Medium Spacing</h3>
+      <HeadingGroup size="2xl" heading="md" subheading="Medium (Default) Spacing"  />
       </Card.Header>
 
       <Card.Section>
@@ -198,7 +177,7 @@ export const Spacings = () => (
 
     <Card spacing="lg">
       <Card.Header className="test-card-header">
-        <h3>Large Spacing</h3>
+        <HeadingGroup size="2xl" heading="lg" subheading="Large Spacing"  />
       </Card.Header>
 
       <Card.Section>
@@ -209,6 +188,17 @@ export const Spacings = () => (
       </Card.Section>
     </Card>
 
-    <style>{sharedStyles}</style>
+    <Card spacing="xl">
+      <Card.Header className="test-card-header">
+        <HeadingGroup size="2xl" heading="xl" subheading="Extra Large Spacing"  />
+      </Card.Header>
+
+      <Card.Section>
+        <p>
+          The term can refer to the flowering plant as a whole, even when not in bloom, and not just
+          the flower.
+        </p>
+      </Card.Section>
+    </Card>
   </div>
 )


### PR DESCRIPTION
## PR Overview

This PR addresses #35 and #37 

## Description

The spacing options for Card have been redone to use regular "t-shirt" sizes.

The stories were also updated to use the HeadingGroup component.

## How Can This Be Tested/Reviewed?

Storybook examples: https://deploy-preview-38--storybook-ui-seeds.netlify.app/?path=/story/blocks-card--spacings

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
