### PR TITLE
fix: add react import to expandabletext

### DIFF
--- a/src/expandableText/ExpandableText.tsx
+++ b/src/expandableText/ExpandableText.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import React from "react"
 import Markdown, { MarkdownOptions } from "markdown-to-jsx"
 import "./ExpandableText.scss"
 
@@ -46,7 +46,7 @@ const moreLessButton = (
 }
 
 const ExpandableText = (props: ExpandableTextProps) => {
-  const [expanded, setExpanded] = useState(props.expand || false)
+  const [expanded, setExpanded] = React.useState(props.expand || false)
   const maxLength = props.maxLength || 350
   let button
 


### PR DESCRIPTION
This PR is a fix to address broken tests in Bloom when attempting to pull in a component from ui-seeds. This has been fixed in other cases by adding the [React import explicitly ](https://stackoverflow.com/questions/64656055/react-refers-to-a-umd-global-but-the-current-file-is-a-module).

