### PR TITLE
fix: prevent empty messaging

### DIFF
--- a/src/blocks/shared/CommonMessage.tsx
+++ b/src/blocks/shared/CommonMessage.tsx
@@ -28,7 +28,7 @@ const CommonMessageIconMap: Record<string, IconDefinition> = {
 
 export interface CommonMessageProps {
   /** Message content */
-  children: React.ReactNode
+  children?: React.ReactNode
   /** Appearance of the component */
   variant?:
     | "primary"
@@ -65,7 +65,7 @@ const CommonMessage = (props: CommonMessageProps) => {
 
   const variant = props.variant || "primary"
 
-  return (
+  return props.children ? (
     <div
       id={props.id}
       className={classNames.join(" ")}
@@ -84,7 +84,7 @@ const CommonMessage = (props: CommonMessageProps) => {
         </button>
       )}
     </div>
-  )
+  ) : null
 }
 
 export default CommonMessage


### PR DESCRIPTION
## Issue Overview

This PR partially addresses https://github.com/bloom-housing/bloom/issues/3434


## Description

As part of the uptake, I noticed that the toast component would still render without a message defined and required me to write out successToastMessage && <Toast>{successToastMessage}</Toast> for every instance. This change should help reduce clutter in uptake across all message types and preserve the intention of conveying a message.

## How Can This Be Tested/Reviewed?

This can be tested by starting up the storybook and removing the children to any component that extends common message and it will not render as opposed to rendering empty.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
