### PR TITLE
fix: text size tokens for Tabs

### DIFF
--- a/src/navigation/Tabs.scss
+++ b/src/navigation/Tabs.scss
@@ -1,7 +1,7 @@
 .seeds-tabs {
   --tab-font: var(--seeds-font-alt-sans);
-  --tab-font-size: var(--seeds-type-body);
-  --tab-font-size-sm: var(--seeds-type-label);
+  --tab-font-size: var(--seeds-type-body-size);
+  --tab-font-size-sm: var(--seeds-type-label-size);
   --tab-font-weight: var(--seeds-font-weight-semibold);
   --tab-font-weight-sm: var(--seeds-font-weight-regular);
   --tab-background-color: var(--seeds-bg-color-surface);

--- a/src/navigation/__stories__/Tabs.docs.mdx
+++ b/src/navigation/__stories__/Tabs.docs.mdx
@@ -25,8 +25,8 @@ import { Swatch } from "../../../documentation/components/Swatch.tsx"
 | Name                           | Description                                             | Default                        |
 | ------------------------------ | ------------------------------------------------------- | ------------------------------ |
 | `--tab-font`                   | Font family                                             | `--seeds-font-alt-sans`        |
-| `--tab-font-size`              | Font size                                               | `--seeds-type-body`            |
-| `--tab-font-size-sm`           | Font size on mobile screens                             | `--seeds-type-label`           |
+| `--tab-font-size`              | Font size                                               | `--seeds-type-body-size`       |
+| `--tab-font-size-sm`           | Font size on mobile screens                             | `--seeds-type-label-size`      |
 | `--tab-font-weight`            | Font weight                                             | `--seeds-font-weight-semibold` |
 | `--tab-font-weight-sm`         | Font weight on mobile screens                           | `--seeds-font-weight-regular`  |
 | `--tab-background-color`       | <Swatch color="bloom-bg-color-surface" border={true} /> | `--seeds-bg-color-surface`     |


### PR DESCRIPTION
## Issue Overview

This PR addresses #55 

## Description

The text size of small tabs should be smaller (right?) than the normal tabs. That wasn't the case once the global semantic text size tokens got renamed, so this fixes it.

## How Can This Be Tested/Reviewed?

Normal tabs: https://deploy-preview-56--storybook-ui-seeds.netlify.app/?path=/story/navigation-tabs--default
Small tabs: https://deploy-preview-56--storybook-ui-seeds.netlify.app/?path=/story/navigation-tabs--small-tabs

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
