### PR TITLE
fix: update `text` variant of Button to align with design

### DIFF
--- a/src/actions/Button.scss
+++ b/src/actions/Button.scss
@@ -22,13 +22,10 @@
   all: initial;
   display: inline-flex;
   gap: var(--button-interior-gap);
-  padding: var(--button-padding-md);
   border-style: solid;
   border-width: var(--button-border-width);
-  border-radius: var(--button-border-radius-md);
   font-family: var(--button-font-family);
   font-weight: var(--button-font-weight);
-  font-size: var(--button-font-size-md);
   line-height: var(--seeds-line-height-tight);
   cursor: pointer;
 
@@ -36,6 +33,12 @@
     padding: var(--button-padding-sm);
     font-size: var(--button-font-size-sm);
     border-radius: var(--button-border-radius-sm);
+  }
+
+  &[data-size="md"] {
+    padding: var(--button-padding-md);
+    font-size: var(--button-font-size-md);
+    border-radius: var(--button-border-radius-md);
   }
 
   &[data-size="lg"] {
@@ -138,22 +141,18 @@
   &[data-variant="text"] {
     background-color: transparent;
     border: none;
-    border-radius: 0;
-    padding: 0;
     color: var(--seeds-color-primary);
     font-weight: normal;
     text-decoration: underline;
     gap: var(--seeds-s1);
 
-    &[data-size="sm"] {
+    &[data-size] {
       padding: 0;
       border-radius: 0;
     }
 
     &[data-size="lg"] {
-      padding: 0;
       font-size: var(--button-font-size-md);
-      border-radius: 0;
     }
   }
 

--- a/src/actions/Button.scss
+++ b/src/actions/Button.scss
@@ -135,13 +135,26 @@
     }
   }
 
-  &[data-variant="borderless-text"] {
+  &[data-variant="text"] {
     background-color: transparent;
-    border-color: transparent;
+    border: none;
+    border-radius: 0;
+    padding: 0;
     color: var(--seeds-color-primary);
     font-weight: normal;
     text-decoration: underline;
     gap: var(--seeds-s1);
+
+    &[data-size="sm"] {
+      padding: 0;
+      border-radius: 0;
+    }
+
+    &[data-size="lg"] {
+      padding: 0;
+      font-size: var(--button-font-size-md);
+      border-radius: 0;
+    }
   }
 
   &:not([data-variant$="-outlined"]) {
@@ -162,11 +175,11 @@
     }
   }
 
-  &.has-lead-icon {
+  &.has-lead-icon:not([data-variant="text"]) {
     padding-inline-start: var(--button-icon-side-padding);
   }
 
-  &.has-tail-icon {
+  &.has-tail-icon:not([data-variant="text"]) {
     padding-inline-end: var(--button-icon-side-padding);
   }
 

--- a/src/actions/Button.tsx
+++ b/src/actions/Button.tsx
@@ -66,7 +66,7 @@ const setupButtonProps = (props: ButtonProps) => {
   return {
     updatedProps: {
       "data-variant": props.variant || "primary",
-      "data-size": props.size,
+      "data-size": props.size || "md",
       id: props.id,
       className: classNames.join(" "),
       "aria-label": props.ariaLabel,

--- a/src/actions/Button.tsx
+++ b/src/actions/Button.tsx
@@ -23,7 +23,7 @@ export interface ButtonProps {
     | "alert-outlined"
     | "highlight"
     | "highlight-outlined"
-    | "borderless-text"
+    | "text"
   /** Button size */
   size?: "sm" | "md" | "lg"
   /** Icon to show before the label text */

--- a/src/actions/Button.tsx
+++ b/src/actions/Button.tsx
@@ -24,7 +24,7 @@ export interface ButtonProps {
     | "highlight"
     | "highlight-outlined"
     | "text"
-  /** Button size */
+  /** Button size (only `sm`/`md` supported by `text` variant) */
   size?: "sm" | "md" | "lg"
   /** Icon to show before the label text */
   leadIcon?: React.ReactNode

--- a/src/actions/__stories__/Button.stories.tsx
+++ b/src/actions/__stories__/Button.stories.tsx
@@ -145,24 +145,24 @@ export const buttonsWithIcons = () => (
   </div>
 )
 
-export const buttonsBorderlessText = () => (
+export const textButtons = () => (
   <>
+    <div style={{ display: "flex", gap: "1rem", marginBlockEnd: "1rem" }}>
+      <Button variant="text">
+        Medium Size
+      </Button>
+      <Button variant="text" size="sm">
+        Small Size
+      </Button>
+    </div>
     <div style={{ display: "flex", gap: "1rem" }}>
-      <Button variant="borderless-text" leadIcon={<Icon icon={faHeart} />}>
+      <Button variant="text" leadIcon={<Icon icon={faHeart} />}>
         Lead Icon
       </Button>
-      <Button variant="borderless-text" tailIcon={<Icon icon={faHeart} />}>
+      <Button variant="text" tailIcon={<Icon icon={faHeart} />}>
         Tail Icon
       </Button>
     </div>
-    <div>
-      {" "}
-      <Button variant="borderless-text" size="sm">
-        Small Size
-      </Button>
-      <Button variant="borderless-text" size="lg">
-        Large Size
-      </Button>
-    </div>
+
   </>
 )


### PR DESCRIPTION
## Issue Overview

This PR addresses QA feedback as noted in #36 

## Description

The `borderless-text` variant has been renamed to `text`, and padding has been removed. There's also just small and medium sizes now (specifying a large size will look identical to medium).

## How Can This Be Tested/Reviewed?

Storybook: https://deploy-preview-58--storybook-ui-seeds.netlify.app/?path=/story/actions-button--text-buttons

## Checklist:

- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
