### PR TITLE
fix: flex justification and sizing on Button

### DIFF
--- a/src/actions/Button.scss
+++ b/src/actions/Button.scss
@@ -20,8 +20,10 @@
   --button-border-radius-lg: var(--seeds-rounded);
 
   all: initial;
+  box-sizing: inherit;
   display: inline-flex;
   gap: var(--button-interior-gap);
+  justify-content: center;
   border-style: solid;
   border-width: var(--button-border-width);
   font-family: var(--button-font-family);


### PR DESCRIPTION
## Description

This is just a couple of small CSS fixes for the `Button` component as I ran into issues with full-width button update in Core.

## How Can This Be Tested/Reviewed?

https://deploy-preview-61--storybook-ui-seeds.netlify.app/
(this should look the same as before, but if you were to edit one of the buttons in browser dev tools to be a specific width like 500px, you'll see that the button is exactly 500px and the text/icon inside is centered)

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
