### PR TITLE
chore: adjust Grid and HeadingGroup spacings and behavior

### DIFF
--- a/src/layout/Grid.scss
+++ b/src/layout/Grid.scss
@@ -4,22 +4,22 @@
   --grid-gap-lg: var(--seeds-s8);
   --grid-gap-xl: var(--seeds-s12);
 
-  --grid-gap-tablet: var(--grid-gap-sm);
+  --grid-gap-mobile: var(--grid-gap-sm);
 
   --grid-gap: var(--grid-gap-md);
 
-  @media (--lg-down) {
-    --grid-gap: var(--grid-gap-tablet);
+  @media (--sm-only) {
+    --grid-gap: var(--grid-gap-mobile);
   }
 
   display: grid;
   gap: var(--grid-gap);
 
-  @media (--lg-and-up) {
-    &[data-spacing="sm"] {
-      --grid-gap: var(--grid-gap-sm);
-    }
+  &[data-spacing="sm"] {
+    --grid-gap: var(--grid-gap-sm);
+  }
 
+  @media (--lg-and-up) {
     &[data-spacing="md"] {
       --grid-gap: var(--grid-gap-md);
     }
@@ -42,6 +42,15 @@
     --grid-columns: 1;
   }
 
+  @media (--sm-and-up) and (--lg-down) {
+    /* This ensures a wide enough min column size at "tablet" breakpoint so that
+     * no more than 2 columns show:
+     */
+    &:not([data-columns="1"]) {
+      --grid-minimum-column-size: 40%; /* a reasonable value below 50% */
+    }
+  }
+
   display: grid;
   gap: inherit;
   grid-template-columns: repeat(var(--grid-columns), minmax(var(--grid-minimum-column-size), 1fr));
@@ -51,7 +60,17 @@
   overflow-wrap: break-word;
 }
 
-@media (--sm-and-up) {
+@media (--lg-and-up) {
+  /* Convenience utility classes for use by grid cells */
+  .seeds-grid-span-2 {
+    grid-column: span 2;
+  }
+
+  .seeds-grid-span-3 {
+    grid-column: span 3;
+  }
+
+  /* Only large screens can force more than two columns */
   .seeds-grid-row[data-columns="4"] {
     --grid-columns: 4;
   }
@@ -59,28 +78,14 @@
   .seeds-grid-row[data-columns="3"] {
     --grid-columns: 3;
   }
+}
 
+@media (--sm-and-up) {
   .seeds-grid-row[data-columns="2"] {
     --grid-columns: 2;
   }
+}
 
-  .seeds-grid-row[data-columns="1"] {
-    --grid-columns: 1;
-  }
-
-  .seeds-grid-row[data-columns="1+2"] {
-    --grid-columns: 4;
-
-    > *:first-child {
-      grid-column: span 2;
-    }
-  }
-
-  .seeds-grid-row[data-columns="2+1"] {
-    --grid-columns: 4;
-
-    > *:last-child {
-      grid-column: span 2;
-    }
-  }
+.seeds-grid-row[data-columns="1"] {
+  --grid-columns: 1;
 }

--- a/src/layout/__stories__/Grid.docs.mdx
+++ b/src/layout/__stories__/Grid.docs.mdx
@@ -24,5 +24,5 @@ import Grid from "../Grid"
 | `--grid-gap-md`     |             | `--seeds-s6`    |
 | `--grid-gap-lg`     |             | `--seeds-s8`    |
 | `--grid-gap-xl`     |             | `--seeds-s12`   |
-| `--grid-gap-tablet` |             | `--grid-gap-sm` |
+| `--grid-gap-mobile` |             | `--grid-gap-sm` |
 | `--grid-gap`        |             | `--grid-gap-md` |

--- a/src/layout/__stories__/Grid.stories.tsx
+++ b/src/layout/__stories__/Grid.stories.tsx
@@ -22,13 +22,10 @@ export const gridExample = () => (
     <Heading size="xl">Three Columns:</Heading>
 
     <Grid spacing="lg">
-      <Grid.Row>
+      <Grid.Row columns={3}>
         <Grid.Cell>Cell 1</Grid.Cell>
         <Grid.Cell>Cell 2</Grid.Cell>
         <Grid.Cell>Cell 3</Grid.Cell>
-      </Grid.Row>
-
-      <Grid.Row columns={3}>
         <Grid.Cell>Cell 4</Grid.Cell>
         <Grid.Cell>Cell 5</Grid.Cell>
         <Grid.Cell>Cell 6</Grid.Cell>
@@ -58,8 +55,8 @@ export const gridExample = () => (
     <Heading size="xl">One Column + Two Columns:</Heading>
 
     <Grid spacing="lg">
-      <Grid.Row columns="1+2">
-        <Grid.Cell>Cell 1 (Long)</Grid.Cell>
+      <Grid.Row columns="4">
+        <Grid.Cell className="seeds-grid-span-2">Cell 1 (Long)</Grid.Cell>
         <Grid.Cell>Cell 2</Grid.Cell>
         <Grid.Cell>Cell 3</Grid.Cell>
       </Grid.Row>
@@ -68,10 +65,10 @@ export const gridExample = () => (
     <Heading size="xl">Two Columns + One Column:</Heading>
 
     <Grid spacing="lg">
-      <Grid.Row columns="2+1">
+      <Grid.Row columns="4">
         <Grid.Cell>Cell 1</Grid.Cell>
         <Grid.Cell>Cell 2</Grid.Cell>
-        <Grid.Cell>Cell 3 (Long)</Grid.Cell>
+        <Grid.Cell className="seeds-grid-span-2">Cell 3 (Long)</Grid.Cell>
       </Grid.Row>
     </Grid>
 

--- a/src/text/HeadingGroup.scss
+++ b/src/text/HeadingGroup.scss
@@ -1,6 +1,7 @@
 .seeds-heading-group {
   --heading-margin: 0rem;
   --subheading-margin: var(--seeds-s4);
+  --subheading-margin-sm: var(--seeds-s3);
   --heading-color: inherit;
   --subheading-color: inherit;
   --subheading-font-size: var(--seeds-font-size-base);
@@ -19,5 +20,9 @@
     margin-block: var(--subheading-margin);
     font-size: var(--subheading-font-size);
     color: var(--subheading-color);
+  }
+
+  :not(.text-heading-4xl, .text-heading-3xl, .text-heading-2xl) + p {
+    margin-block-start: var(--subheading-margin-sm);
   }
 }

--- a/src/text/__stories__/HeadingGroup.docs.mdx
+++ b/src/text/__stories__/HeadingGroup.docs.mdx
@@ -10,10 +10,11 @@ import HeadingGroup from "../HeadingGroup"
 
 ## Theme Variables
 
-| Name                     | Description                                         | Default                  |
-| ------------------------ | --------------------------------------------------- | ------------------------ |
-| `--heading-margin`       | Vertical space added around the top heading, if any | `0rem`                   |
-| `--subheading-margin`    | The space between the heading and subheading        | `--seeds-s4`             |
-| `--heading-color`        | The heading text color                              | `inherit`                |
-| `--subheading-color`     | The subheading text color                           | `inherit`                |
-| `--subheading-font-size` | The subheading font size                            | `--seeds-font-size-base` |
+| Name                     | Description                                                    | Default                  |
+| ------------------------ | -------------------------------------------------------------- | ------------------------ |
+| `--heading-margin`       | Vertical space added around the top heading, if any            | `0rem`                   |
+| `--subheading-margin`    | The space between the heading and subheading                   | `--seeds-s4`             |
+| `--subheading-margin-sm` | The space between smaller headings (xl on down) and subheading | `--seeds-s3`             |
+| `--heading-color`        | The heading text color                                         | `inherit`                |
+| `--subheading-color`     | The subheading text color                                      | `inherit`                |
+| `--subheading-font-size` | The subheading font size                                       | `--seeds-font-size-base` |


### PR DESCRIPTION
## Issue Overview

This PR addresses feedback based on design QA and on uptake issues related to:
https://github.com/bloom-housing/bloom/pull/3643

## Description

Several changes are involved (and we'll want to update zero height accordingly post-merge):

* The previous "1+2" and "2+1" columns stuff didn't really make sense in light of how the grids were working in the Partners site. It makes more sense to specify that certain cells can span 2 or 3 of the grid columns. This includes utility classes for that purpose. (They're not done via props because multiple types of components can serve as grid cells.)
* Medium-size screens (like tablets) should limit the total number of columns to two, so this was done on a cell-width basis in CSS.
* Medium screen grids should show medium grid gap (and mobile is still small gap).
* Small tweaks to heading group spacing for Partners use case is also included.

## How Can This Be Tested/Reviewed?

You can look at Grid and HeadingGroup stories, but it's probably hard to tell what's going on until this can be applied via the Grid uptake PR.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
