### PR TITLE
chore: loading state for Button

### DIFF
--- a/src/actions/Button.scss
+++ b/src/actions/Button.scss
@@ -196,4 +196,43 @@
     outline: var(--seeds-focus-ring-outline);
     box-shadow: var(--seeds-focus-ring-box-shadow);
   }
+
+  // loading indicator
+  &::after {
+    content: "";
+    position: absolute;
+    display: block;
+    width: 1.5em;
+    height: 1.5em;
+    top: calc(50% - .75em);
+    left: calc(50% - .75em);
+    border: 3px solid var(--seeds-color-on-inverse);
+    border-left-color: transparent;
+    border-radius: 50%;
+    opacity: 0;
+    transition: opacity 250ms;
+  }
+
+  &[data-loading="true"] {
+    position: relative;
+    color: transparent;
+
+    &::after {
+      opacity: 1;
+      animation: spinning-rotation 1s linear infinite;
+    }
+
+    .btnSubmit-text {
+      visibility: hidden;
+    }
+  }
+}
+
+@keyframes spinning-rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/src/actions/Button.tsx
+++ b/src/actions/Button.tsx
@@ -47,8 +47,8 @@ export interface ButtonProps {
   ariaHidden?: boolean
   /** Accessible label if button doesn't contain text content */
   ariaLabel?: string
-  /** ARIA live message which also shows loading spinner and disables clicks */
-  loadingSpinnerMessage?: string
+  /** Show loading spinner and set ARIA live message while disabling clicks */
+  loadingMessage?: string | null
   /** Element ID */
   id?: string
   /** Additional CSS classes */
@@ -77,13 +77,13 @@ const setupButtonProps = (props: ButtonProps) => {
     updatedProps: {
       "data-variant": props.variant || "primary",
       "data-size": props.size || "md",
-      "data-loading": props.loadingSpinnerMessage ? "true" : undefined,
+      "data-loading": props.loadingMessage ? "true" : undefined,
       id: props.id,
       className: classNames.join(" "),
       target: props.newWindowTarget ? "_blank" : undefined,
       "aria-label": props.ariaLabel,
       "aria-hidden": props.ariaHidden,
-      "aria-disabled": props.loadingSpinnerMessage ? "true" : undefined,
+      "aria-disabled": props.loadingMessage ? "true" : undefined,
       tabIndex: props.ariaHidden ? -1 : null,
     },
     inner: {
@@ -120,7 +120,7 @@ const Button = (props: ButtonProps) => {
       {inner.leadIcon}
       {inner.children}
       {inner.tailIcon}
-      {!props.href && <span className="seeds-screen-reader-only" aria-live="assertive">{props.loadingSpinnerMessage}</span>}
+      {!props.href && <span className="seeds-screen-reader-only" aria-live="assertive">{props.loadingMessage}</span>}
     </>
   )
 
@@ -135,7 +135,7 @@ const Button = (props: ButtonProps) => {
       <ButtonElement
         type={props.type || "button"}
         disabled={props.disabled}
-        onClick={props.loadingSpinnerMessage ? (event) => event.preventDefault : props.onClick}
+        onClick={props.loadingMessage ? (event) => event.preventDefault : props.onClick}
         {...updatedProps}
       >
         {buttonInner}

--- a/src/actions/Button.tsx
+++ b/src/actions/Button.tsx
@@ -47,6 +47,8 @@ export interface ButtonProps {
   ariaHidden?: boolean
   /** Accessible label if button doesn't contain text content */
   ariaLabel?: string
+  /** ARIA live message which also shows loading spinner and disables clicks */
+  loadingSpinnerMessage?: string
   /** Element ID */
   id?: string
   /** Additional CSS classes */
@@ -75,11 +77,13 @@ const setupButtonProps = (props: ButtonProps) => {
     updatedProps: {
       "data-variant": props.variant || "primary",
       "data-size": props.size || "md",
+      "data-loading": props.loadingSpinnerMessage ? "true" : undefined,
       id: props.id,
       className: classNames.join(" "),
       target: props.newWindowTarget ? "_blank" : undefined,
       "aria-label": props.ariaLabel,
       "aria-hidden": props.ariaHidden,
+      "aria-disabled": props.loadingSpinnerMessage ? "true" : undefined,
       tabIndex: props.ariaHidden ? -1 : null,
     },
     inner: {
@@ -116,6 +120,7 @@ const Button = (props: ButtonProps) => {
       {inner.leadIcon}
       {inner.children}
       {inner.tailIcon}
+      {!props.href && <span className="seeds-screen-reader-only" aria-live="assertive">{props.loadingSpinnerMessage}</span>}
     </>
   )
 
@@ -130,7 +135,7 @@ const Button = (props: ButtonProps) => {
       <ButtonElement
         type={props.type || "button"}
         disabled={props.disabled}
-        onClick={props.onClick}
+        onClick={props.loadingSpinnerMessage ? (event) => event.preventDefault : props.onClick}
         {...updatedProps}
       >
         {buttonInner}

--- a/src/actions/Button.tsx
+++ b/src/actions/Button.tsx
@@ -120,7 +120,6 @@ const Button = (props: ButtonProps) => {
       {inner.leadIcon}
       {inner.children}
       {inner.tailIcon}
-      {!props.href && <span className="seeds-screen-reader-only" aria-live="assertive">{props.loadingMessage}</span>}
     </>
   )
 
@@ -139,6 +138,7 @@ const Button = (props: ButtonProps) => {
         {...updatedProps}
       >
         {buttonInner}
+        <span className="seeds-screen-reader-only" aria-live="assertive">{props.loadingMessage}</span>
       </ButtonElement>
     )
   }

--- a/src/actions/__stories__/Button.stories.tsx
+++ b/src/actions/__stories__/Button.stories.tsx
@@ -171,3 +171,8 @@ export const textButtons = () => (
 
   </>
 )
+
+export const loadingButton = () => {
+  const [loading, setLoading] = React.useState<undefined | string>()
+  return <Button loadingSpinnerMessage={loading} onClick={() => setLoading("Saving form")}>Click to Spin</Button>
+}

--- a/src/actions/__stories__/Button.stories.tsx
+++ b/src/actions/__stories__/Button.stories.tsx
@@ -173,6 +173,9 @@ export const textButtons = () => (
 )
 
 export const loadingButton = () => {
-  const [loading, setLoading] = React.useState<undefined | string>()
-  return <Button loadingSpinnerMessage={loading} onClick={() => setLoading("Saving form")}>Click to Spin</Button>
+  const [loading, setLoading] = React.useState<null | string>(null)
+  return <Button loadingMessage={loading} onClick={() => {
+    setLoading("Saving form")
+    setTimeout(() => setLoading(null), 3000)
+  }}>Click to Spin</Button>
 }


### PR DESCRIPTION
## Issue Overview

This PR addresses #64 

## Description

This PR adds a `loadingMessage` prop which will display a loading spinner, make clicks disabled, and also announce an ARIA live message.

## How Can This Be Tested/Reviewed?

This Storybook example:
https://deploy-preview-67--storybook-ui-seeds.netlify.app/?path=/story/actions-button--loading-button

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
