### PR TITLE
docs: add license and readme

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Exygy, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Finally, import the primary CSS entrypoint for Seeds in your `_app.tsx` file:
 import "@bloom-housing/ui-seeds/src/global/app-css.scss"
 ```
 
-Now you can import individual Seeds components on the pages where you need to use them.
+Now you can import individual Seeds React components on the pages where you need to use them.
 
 ## Contributing
 
@@ -55,7 +55,7 @@ Design tokens are broken out into two layers: **base tokens** and **semantic tok
 
 For example, `--seeds-color-blue-500` is set to `#0077da`. In addition, `--seeds-color-primary` is set to `var(--seeds-color-blue-500)`. Your component should utilize `--seeds-color-primary` rather than `--seeds-color-blue-500`, unless you know for certain you _always_ need to use that particular color regardless of downstream theme changes.
 
-Components are encouraged to set up their own component specific tokens, which can leverage both semantic or base tokens (when a suitable semantic token isn't available). For example:
+Components are encouraged to set up their own component-specific tokens, which can leverage both semantic or base tokens (when a suitable semantic token isn't available). For example:
 
 ```css
 .seeds-card {
@@ -64,13 +64,40 @@ Components are encouraged to set up their own component specific tokens, which c
 }
 ```
 
-Various parts/subcomponents within a component can consume component tokens which have been defined at the top-level.
+Various parts/subcomponents within a component many consume component tokens which have been defined at this top-level.
 
-### Components
+We don't encourage defining tokens below the top-level, as consumers would then have to know about the internal DOM structure of a component which is bad for future-compatibility.
+
+```css
+/* Bad */
+.seeds-component {
+  --component-token-1: var(--seeds-s3);
+
+  padding: var(--component-token-1);
+
+  > .seeds-component-section {
+    --component-token-2: var(--seeds-s5);
+
+    padding: var(--component-token-2);
+  }
+}
+
+/* Good */
+.seeds-component {
+  --component-token-1: var(--seeds-s3);
+  --component-section-token-1: var(--seeds-s5);
+
+  > .seeds-component-section {
+    padding: var(--component-section-token-1);
+  }
+}
+```
+
+### Component Definitions
 
 Components are built as functional React components, with filenames to match the component name. So `FieldValue.tsx` exports a component named `FieldValue`. Component files are located next to "sidecar" `.scss` files containing styles for the component.
 
-A component class is a kebab-cased name of the component prefixed with `seeds`. So the `FieldValue` component is associated with the `seeds-field-value` class name.
+A component class is a kebab-cased name of the component prefixed with `seeds`. So the `FieldValue` component would associated with the `seeds-field-value` class name.
 
 Components may offer many variations such as color/type variants, sizes, etc. It is encouraged to use `data-*` attributes in your HTML to specify these variations:
 
@@ -102,12 +129,22 @@ Then in your stylesheet, you can add style rules based on these attributes:
 }
 ```
 
-Some boolean-style variations or "states" are simply easier to do as conditional classes. In that case, we typically use `is-` or `has-` prefixes, e.g. `is-fullwidth` or `has-lead-icon`.
+Some boolean-style variations or "states" are more straightforward to do as conditional classes. In that case, we typically use `is-` or `has-` prefixes, e.g. `.is-fullwidth` or `.has-lead-icon`.
+
+Some states are also better expressed through the use of ARIA roles and attributes. If ARIA needs to be managed through the HTML markup anyway, it's best to hang styles off of those instead of introducing duplication through additional attributes/classes.
 
 ### Documentation
 
-Component props are documented using TypeScript interfaces.
+Storybook stories are written in the `__stories__` folders in `.stories.tsx` files. These stories can then be displayed in documentation within zeroheight.
+
+In addition, the `.docs.mdx` files will provide a display of props and styling information.
+
+Component props are documented using TypeScript interfaces along with JSDoc comments. These comments will show up in Storybook when using the `ArgsTable` component in the MDX files.
+
+Component tokens are also documented using a Markdown table in the story MDX files.
+
+In zeroheight, stories can easily be embedded one-by-one due to the integration which was set up. However, to embed the props/styles docs pages, you will need to open up Storybook, click the "Docs" tab for a component, and copy the URL to an "iframe" embed within zeroheight.
 
 ## Testing
 
-
+Unit tests are located within `__tests__` folders, written with React's Testing Library and executed via Jest. Unit tests are intended to verify the basic functionality of a component along with any major branches in display logic.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seeds – Component Library for Bloom
 
-This package is the home of the core UI components for the Bloom affordable housing system, meant to be imported from one or more applications that provide the end-user interface.
+This package serves as the home of [Bloom](https://www.exygy.com/housing)'s core UI components, meant to be imported from one or more Bloom applications. Seeds supersedes Bloom's previous "ui-components" package.
 
 Seeds is built using TypeScript, React, and Sass. It uses Storybook for concrete component examples and Jest for testing.
 
@@ -45,6 +45,69 @@ Now you can import individual Seeds components on the pages where you need to us
 
 ## Contributing
 
+Seeds is comprised primarily of **design tokens** and **components**. There are a handful of global style rules and utility classes, but they are intentionally kept to a minimum. Component-scoped style rules whenever possible are preferable.
 
+For design tokens, component classes, and utility classes, it is generally recommended to start with the `seeds` prefix.
+
+### Design Tokens
+
+Design tokens are broken out into two layers: **base tokens** and **semantic tokens**. Semantic tokens _consume_ the base tokens. Whenever possible, components should rely on semantic tokens rather than base tokens. This will allow for easy customization of the theme downstream (consumers are encouraged to override semantic tokens, _not_ base tokens).
+
+For example, `--seeds-color-blue-500` is set to `#0077da`. In addition, `--seeds-color-primary` is set to `var(--seeds-color-blue-500)`. Your component should utilize `--seeds-color-primary` rather than `--seeds-color-blue-500`, unless you know for certain you _always_ need to use that particular color regardless of downstream theme changes.
+
+Components are encouraged to set up their own component specific tokens, which can leverage both semantic or base tokens (when a suitable semantic token isn't available). For example:
+
+```css
+.seeds-card {
+  --card-spacing-md: var(--seeds-s6); /* a base token */
+  --card-background-color: var(--seeds-bg-color-surface); /* a semantic token */
+}
+```
+
+Various parts/subcomponents within a component can consume component tokens which have been defined at the top-level.
+
+### Components
+
+Components are built as functional React components, with filenames to match the component name. So `FieldValue.tsx` exports a component named `FieldValue`. Component files are located next to "sidecar" `.scss` files containing styles for the component.
+
+A component class is a kebab-cased name of the component prefixed with `seeds`. So the `FieldValue` component is associated with the `seeds-field-value` class name.
+
+Components may offer many variations such as color/type variants, sizes, etc. It is encouraged to use `data-*` attributes in your HTML to specify these variations:
+
+```jsx
+<span
+  id={props.id}
+  className={classNames.join(" ")}
+  data-variant={props.variant || "primary"}
+  data-size={props.size}
+  aria-label={props.ariaLabel}
+>
+  {props.children}
+</span>
+```
+
+Then in your stylesheet, you can add style rules based on these attributes:
+
+```css
+.seeds-tag {
+  &[data-variant="primary"] {
+    background-color: var(--seeds-color-primary-light);
+    color: var(--seeds-color-primary-dark);
+  }
+
+  &[data-size="lg"] {
+    font-size: var(--tag-font-size-lg);
+    font-weight: var(--tag-font-weight-lg);
+  }
+}
+```
+
+Some boolean-style variations or "states" are simply easier to do as conditional classes. In that case, we typically use `is-` or `has-` prefixes, e.g. `is-fullwidth` or `has-lead-icon`.
+
+### Documentation
+
+Component props are documented using TypeScript interfaces.
 
 ## Testing
+
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Seeds is built using TypeScript, React, and Sass. It uses Storybook for concrete
 
 We use [zeroheight to document tokens, components, and patterns](https://zeroheight.com/5e69dd4e1/p/938cb5-seeds-design-system) for the Seeds Design System.
 
+For code-level changes over time, [see GitHub Releases for Changelog](https://github.com/bloom-housing/ui-seeds/releases).
+
 ## Usage
 
 ### Next.js

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
-# Bloom UI Seeds
+# Seeds – Component Library for Bloom
 
 This package is the home of the core UI components for the Bloom affordable housing system, meant to be imported from one or more applications that provide the end-user interface.
+
+Seeds is built using TypeScript, React, and Sass. It uses Storybook for concrete component examples and Jest for testing.
+
+## Design System Documentation
+
+We use [zeroheight to document tokens, components, and patterns](https://zeroheight.com/5e69dd4e1/p/938cb5-seeds-design-system) for the Seeds Design System.
+
+## Usage
+
+### Next.js
+
+To get Seeds set up, first add the `@bloom-housing/ui-seeds` package via npm or yarn. Next, update `next.config.js` to include the package name in its `transpilePackages` config option:
+
+```js
+  transpilePackages: [
+    "@bloom-housing/ui-seeds"
+  ]
+```
+
+You will need to have Sass & PostCSS installed, along with the `@csstools/postcss-global-data` & `postcss-custom-media` packages. Ensure they are available via the `postcss.config.js` file:
+
+```js
+  plugins: {
+    "@csstools/postcss-global-data": {
+      // in the Bloom monorepo, this starts with `../../`:
+      files: ["node_modules/@bloom-housing/ui-seeds/src/global/tokens/screens.scss"],
+    },
+    "postcss-custom-media": {},
+    ...
+  }
+```
+
+Finally, import the primary CSS entrypoint for Seeds in your `_app.tsx` file:
+
+```js
+import "@bloom-housing/ui-seeds/src/global/app-css.scss"
+```
+
+Now you can import individual Seeds components on the pages where you need to use them.
+
+## Contributing
+
+
+
+## Testing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seeds – Component Library for Bloom
 
-This package serves as the home of [Bloom](https://www.exygy.com/housing)'s core UI components, meant to be imported from one or more Bloom applications. Seeds supersedes Bloom's previous "ui-components" package.
+This package serves as the home of [Bloom](https://www.exygy.com/housing)'s core UI components, meant to be imported from within various applications. Seeds supersedes Bloom's previous "ui-components" package.
 
 Seeds is built using TypeScript, React, and Sass. It uses Storybook for concrete component examples and Jest for testing.
 

--- a/src/blocks/Card.scss
+++ b/src/blocks/Card.scss
@@ -7,10 +7,10 @@
 
   --card-spacing: var(--card-spacing-md);
 
-  --card-background-color: var(--seeds-color-white);
+  --card-background-color: var(--seeds-bg-color-surface);
   --card-border-radius: var(--seeds-rounded-lg);
   --card-border-width: var(--seeds-border-1);
-  --card-border-color: var(--seeds-color-gray-450);
+  --card-border-color: var(--seeds-border-color);
   --card-divider-width: var(--card-border-width);
   --card-divider-color: var(--card-border-color);
 


### PR DESCRIPTION
## Issue Overview

This PR addresses #40 

## Description

An Apache license is now included just like in other Bloom repos, and a Readme now features preliminary documentation around how the styles and React components should be set up along with info on Storybook and zeroheight.

Feedback and more ideas of what to include most welcome!

(Also I found a couple of design tokens for Card I could replace with semantic equivalents...visual appearance should be identical.)

## Checklist:

- [x] I have made corresponding changes to the documentation

