### PR TITLE
fix: make TS happy with explicit return

### DIFF
--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -20,6 +20,8 @@ export default function useTimeout(callback: () => void, delay?: number) {
     if (delay) {
       timeoutRef.current = window.setTimeout(tick, delay)
       return () => window.clearTimeout(timeoutRef.current as number)
+    } else {
+      return () => {} // makes TS happy to have an explicit return
     }
   }, [delay])
 


### PR DESCRIPTION
## Description

The `shared-helpers` linter in the core Bloom repo was failing due to an implicit return in Seeds' `useTimeout` hook. This adds an explicit return so that the linter will be happy.

## How Can This Be Tested/Reviewed?

I tested the fix in the local `node_modules` copy of ui-seeds and the shared-helpers Jest tests passed.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
