### PR TITLE
fix: improvements to Toast sizes and spacing

### DIFF
--- a/src/blocks/Toast.scss
+++ b/src/blocks/Toast.scss
@@ -1,8 +1,8 @@
 #seeds-toast-stack {
   --toast-stack-gap: var(--seeds-s4);
-  --toast-stack-inset-top: var(--seeds-s3);
-  --toast-stack-inset-right: var(--seeds-s3);
-  --toast-stack-max-width: var(--seeds-width-sm);
+  --toast-stack-inset-top: var(--seeds-s4);
+  --toast-stack-inset-right: var(--seeds-s4);
+  --toast-stack-width: auto;
 
   position: fixed;
   z-index: var(--seeds-z-index-overlay);
@@ -11,7 +11,7 @@
   gap: var(--toast-stack-gap);
   top: var(--toast-stack-inset-top);
   right: var(--toast-stack-inset-right);
-  width: var(--toast-stack-max-width);
+  width: var(--toast-stack-width);
   max-width: calc(100% - var(--toast-stack-inset-right) * 2);
 }
 

--- a/src/blocks/__stories__/Toast.docs.mdx
+++ b/src/blocks/__stories__/Toast.docs.mdx
@@ -24,9 +24,9 @@ import Toast from "../Toast"
 
 In addition, there are a set of variables you can customize via `#toast-stack` which affects the fixed container within which toasts are rendered:
 
-| Name                        | Description                      | Default            |
-| --------------------------- | -------------------------------- | ------------------ |
-| `--toast-stack-gap`         | Spacing between toasts           | `--seeds-s4`       |
-| `--toast-stack-inset-top`   | Window top edge -> stack space   | `--seeds-s3`       |
-| `--toast-stack-inset-right` | Window right edge -> stack space | `--seeds-s3`       |
-| `--toast-stack-max-width`   | Size                             | `--seeds-width-sm` |
+| Name                        | Description                      | Default      |
+| --------------------------- | -------------------------------- | ------------ |
+| `--toast-stack-gap`         | Spacing between toasts           | `--seeds-s4` |
+| `--toast-stack-inset-top`   | Window top edge -> stack space   | `--seeds-s4` |
+| `--toast-stack-inset-right` | Window right edge -> stack space | `--seeds-s4` |
+| `--toast-stack-width`       | Size                             | `auto`       |

--- a/src/blocks/__stories__/Toast.stories.tsx
+++ b/src/blocks/__stories__/Toast.stories.tsx
@@ -61,7 +61,7 @@ export const showToasts = () => {
       )}
       {warning && (
         <Toast variant="warn" hideTimeout={5000}>
-          Warn message!
+          Warn message! (And a long bit of text to see what happens)
         </Toast>
       )}
     </>


### PR DESCRIPTION
## Issue Overview

## Description

Based on feedback from Toast uptake (see https://github.com/bloom-housing/bloom/pull/3553), this fixes a few size/spacing issues.

## How Can This Be Tested/Reviewed?

In the Toast examples, you'll see that the width resizes to the length of text (up to a certain point, then it starts to wrap). And the top/right page space has been bumped up a size token.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
