### PR TITLE
fix: temp vertical tabs

### DIFF
--- a/src/navigation/Tabs.scss
+++ b/src/navigation/Tabs.scss
@@ -19,7 +19,7 @@
   --tab-active-indicator-color: var(--seeds-color-primary);
   --tab-panel-padding: var(--seeds-spacer-section);
   --tab-panel-background-color: var(--seeds-bg-color-surface);
-  @custom-media --tab-collapse-breakpoint (max-width: --sm-only);
+  @custom-media --tab-collapse-breakpoint (--sm-only);
 }
 
 .tabs-tablist {

--- a/src/navigation/Tabs.scss
+++ b/src/navigation/Tabs.scss
@@ -19,6 +19,7 @@
   --tab-active-indicator-color: var(--seeds-color-primary);
   --tab-panel-padding: var(--seeds-spacer-section);
   --tab-panel-background-color: var(--seeds-bg-color-surface);
+  @custom-media --tab-collapse-breakpoint (max-width: --sm-only);
 }
 
 .tabs-tablist {
@@ -105,7 +106,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@media (--tab-collapse-breakpoint) {
   .tabs-tablist {
     flex-direction: column;
   }

--- a/src/navigation/__stories__/Tabs.docs.mdx
+++ b/src/navigation/__stories__/Tabs.docs.mdx
@@ -43,3 +43,4 @@ import { Swatch } from "../../../documentation/components/Swatch.tsx"
 | `--tab-active-indicator-color` | <Swatch color="bloom-color-primary" />                  | `--seeds-color-primary`        |
 | `--tab-panel-padding`          | Spacing within the panel interior                       | `--seeds-spacer-section`       |
 | `--tab-panel-background-color` | <Swatch color="bloom-bg-color-surface" border={true} /> | `--seeds-bg-color-surface`     |
+| `--tab-panel-background-color` | <Swatch color="bloom-bg-color-surface" border={true} /> | `--seeds-bg-color-surface`     |

--- a/src/navigation/__stories__/Tabs.docs.mdx
+++ b/src/navigation/__stories__/Tabs.docs.mdx
@@ -43,4 +43,4 @@ import { Swatch } from "../../../documentation/components/Swatch.tsx"
 | `--tab-active-indicator-color` | <Swatch color="bloom-color-primary" />                  | `--seeds-color-primary`        |
 | `--tab-panel-padding`          | Spacing within the panel interior                       | `--seeds-spacer-section`       |
 | `--tab-panel-background-color` | <Swatch color="bloom-bg-color-surface" border={true} /> | `--seeds-bg-color-surface`     |
-| `--tab-panel-background-color` | <Swatch color="bloom-bg-color-surface" border={true} /> | `--seeds-bg-color-surface`     |
+| `--tab-collapse-breakpoint`    | Screen size breakpoint for vertical orientation         | `--sm-only`                    |


### PR DESCRIPTION
## Issue Overview

This PR partially addresses #73

## Description

This PR allows for the tab orientation breakpoint to be overridden by a consumer. It is a temporary fix to allow for the tab component to be displayed vertically on all screen sizes.

## How Can This Be Tested/Reviewed?

This can be tested by adding "@custom-media --tab-collapse-breakpoint (max-width: 10000px);" to the tabs-tablist class to show it can be overriden.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
