### PR TITLE
feat: add support for `aria-expanded` to Seeds button

### DIFF
--- a/src/actions/Button.tsx
+++ b/src/actions/Button.tsx
@@ -49,6 +49,10 @@ export interface ButtonProps {
   ariaHidden?: boolean
   /** Accessible label if button doesn't contain text content */
   ariaLabel?: string
+  /** The ID of an element you're expanding/collapsing as indicated by `ariaExpanded` */
+  ariaControls?: string
+  /** The expanded or collapsed state of the element whose ID is specified via `ariaControls` */
+  ariaExpanded?: boolean
   /** Show loading spinner and set ARIA live message while disabling clicks */
   loadingMessage?: string | null
   /** Element ID */
@@ -85,6 +89,8 @@ const setupButtonProps = (props: ButtonProps) => {
       target: props.newWindowTarget ? "_blank" : undefined,
       "aria-label": props.ariaLabel,
       "aria-hidden": props.ariaHidden,
+      "aria-controls": props.ariaControls,
+      "aria-expanded": props.ariaExpanded,
       "aria-disabled": props.loadingMessage ? "true" : undefined,
       tabIndex: props.ariaHidden ? -1 : null,
     },
@@ -140,7 +146,9 @@ const Button = (props: ButtonProps) => {
         {...updatedProps}
       >
         {buttonInner}
-        <span className="seeds-screen-reader-only" aria-live="assertive">{props.loadingMessage}</span>
+        <span className="seeds-screen-reader-only" aria-live="assertive">
+          {props.loadingMessage}
+        </span>
       </ButtonElement>
     )
   }

--- a/src/actions/__stories__/Button.stories.tsx
+++ b/src/actions/__stories__/Button.stories.tsx
@@ -171,9 +171,7 @@ export const buttonsWithIcons = () => (
 export const textButtons = () => (
   <>
     <div style={{ display: "flex", gap: "1rem", marginBlockEnd: "1rem" }}>
-      <Button variant="text">
-        Medium Size
-      </Button>
+      <Button variant="text">Medium Size</Button>
       <Button variant="text" size="sm">
         Small Size
       </Button>
@@ -186,14 +184,39 @@ export const textButtons = () => (
         Tail Icon
       </Button>
     </div>
-
   </>
 )
 
 export const loadingButton = () => {
   const [loading, setLoading] = React.useState<null | string>(null)
-  return <Button loadingMessage={loading} onClick={() => {
-    setLoading("Saving form")
-    setTimeout(() => setLoading(null), 3000)
-  }}>Click to Spin</Button>
+  return (
+    <Button
+      loadingMessage={loading}
+      onClick={() => {
+        setLoading("Saving form")
+        setTimeout(() => setLoading(null), 3000)
+      }}
+    >
+      Click to Spin
+    </Button>
+  )
+}
+
+export const expandingButton = () => {
+  const [expanded, setExpanded] = React.useState<boolean>(false)
+
+  return (
+    <>
+      <Button
+        onClick={() => setExpanded(!expanded)}
+        ariaControls="show-or-hide"
+        ariaExpanded={expanded}
+      >
+        {expanded ? "Hide Content" : "Show Content"}
+      </Button>
+      <p id="show-or-hide" hidden={!expanded}>
+        Content that should only appear in the "expanded" state.
+      </p>
+    </>
+  )
 }


### PR DESCRIPTION
## Issue Overview

This PR addresses #76 

## Description

ARIA features that had been added before to UI Components Button were missing from Seeds. This PR adds those in.

## How Can This Be Tested/Reviewed?

Storybook: https://deploy-preview-78--storybook-ui-seeds.netlify.app/?path=/story/actions-button--expanding-button

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
