### PR TITLE
feat: 512 CheckboxGroup

### DIFF
--- a/src/forms/CheckboxGroup.scss
+++ b/src/forms/CheckboxGroup.scss
@@ -1,0 +1,15 @@
+.seeds-checkbox-group {
+  --inner-button-gap: var(--seeds-s3);
+  display: flex;
+  gap: var(--inner-button-gap);
+}
+
+.seeds-checkbox-hide {
+  opacity: 0;
+  position: absolute;
+}
+
+.seeds-checkbox-hide:focus-visible + .seeds-button {
+  outline: var(--seeds-focus-ring-outline);
+  box-shadow: var(--seeds-focus-ring-box-shadow);
+}

--- a/src/forms/CheckboxGroup.tsx
+++ b/src/forms/CheckboxGroup.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+
+import "./CheckboxGroup.scss"
+import "../actions/Button.scss"
+import { ButtonProps } from "actions/Button"
+
+export interface CheckboxGroupProps extends Pick<ButtonProps, "size" | "variant"> {
+  /** Label content */
+  label?: string
+  /** Current selected values*/
+  values: string[]
+  /** An array of strings representing each item in the group*/
+  options: string[]
+  /** Element ID */
+  id: string
+  /** Additional CSS classes */
+  className?: string
+  /** ID for selecting in tests */
+  testId?: string
+  /** function to call when a checkbox is clicked*/
+  onChange: (values: string[]) => void
+  /** Appearance of the checked input*/
+  checkedVariant?:
+    | "primary"
+    | "primary-outlined"
+    | "secondary"
+    | "secondary-outlined"
+    | "success"
+    | "success-outlined"
+    | "alert"
+    | "alert-outlined"
+    | "highlight"
+    | "highlight-outlined"
+    | "text"
+}
+
+const CheckboxGroup = (props: CheckboxGroupProps) => {
+  const classNames = ["seeds-checkbox-group"]
+  if (props.className) classNames.push(props.className)
+
+  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = event.target
+    const newValue = checked ? [...props.values, name] : props.values.filter((v) => v !== name)
+    props.onChange(newValue)
+  }
+
+  return (
+    <div id={props.id} className={classNames.join(" ")} data-testid={props.testId}>
+      {props.options.map((option) => (
+        <div key={`${option}-container`}>
+          <input
+            type="checkbox"
+            name={option}
+            id={option}
+            checked={props.values.includes(option)}
+            onChange={handleCheckboxChange}
+            className="seeds-checkbox-hide"
+          />
+          <label
+            className="seeds-button"
+            data-variant={
+              props.values.includes(option)
+                ? props.checkedVariant || "primary"
+                : props.variant || "secondary"
+            }
+            data-size={props.size || "lg"}
+            htmlFor={option}
+          >
+            {option}
+          </label>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default CheckboxGroup

--- a/src/forms/__stories_/CheckboxGroup.docs.mdx
+++ b/src/forms/__stories_/CheckboxGroup.docs.mdx
@@ -1,0 +1,34 @@
+import { ArgsTable } from "@storybook/addon-docs"
+import CheckboxGroup from "../CheckboxGroup"
+
+# &lt;CheckboxGroup /&gt;
+
+## Properties
+
+<ArgsTable of={CheckboxGroup} />
+
+## Theme Variables
+
+| Name                            | Description                               | Default                 |
+| ------------------------------- | ----------------------------------------- | ----------------------- |
+| `--inner-button-gap`            | Space between elements                    | `--seeds-s3`            |
+
+## Theme Variables from Button Styles
+
+| Name                            | Description                               | Default                 |
+| ------------------------------- | ----------------------------------------- | ----------------------- |
+| `--button-border-width`         | Border width                              | `--seeds-border-2`      |
+| `--button-font-family`          | Font family                               | `--seeds-font-alt-sans` |
+| `--button-font-weight`          | Font weight                               | `none`                  |
+| `--button-interior-gap`         | Space between icons/text                  | `--seeds-s3`            |
+| `--button-icon-size-percentage` | Relative size to base font                | `75%`                   |
+| `--button-icon-side-padding`    | Space between an icon and the button edge | `--seeds-s4`            |
+| `--button-padding-sm`           | Small button padding                      |                         |
+| `--button-font-size-sm`         | Small button font size                    | `--seeds-font-size-sm`  |
+| `--button-border-radius-sm`     | Small button border radius                | `--seeds-rounded`       |
+| `--button-padding-md`           | Medium button padding                     |                         |
+| `--button-font-size-md`         | Medium button font size                   | `--seeds-font-size-md`  |
+| `--button-border-radius-md`     | Medium button border radius               | `--seeds-rounded`       |
+| `--button-padding-lg`           | Large button padding                      |                         |
+| `--button-font-size-lg`         | Large button font size                    | `--seeds-font-size-lg`  |
+| `--button-border-radius-lg`     | Large button border radius                | `--seeds-rounded`       |

--- a/src/forms/__stories_/CheckboxGroup.stories.tsx
+++ b/src/forms/__stories_/CheckboxGroup.stories.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react"
+import CheckboxGroup from "../CheckboxGroup"
+
+import MDXDocs from "./CheckboxGroup.docs.mdx"
+
+export default {
+  title: "Forms/CheckboxGroup",
+  component: CheckboxGroup,
+  parameters: {
+    docs: {
+      page: MDXDocs,
+    },
+  },
+}
+
+export const Standalone = () => {
+  const options = ["1", "2", "3"]
+  const [values, setValues] = useState<string[]>([])
+
+  return (
+      <CheckboxGroup
+        label={"My Checkbox Group"}
+        values={values}
+        options={options}
+        id={"MyCheckboxGroup"}
+        onChange={setValues}
+      />
+  )
+}
+
+export const WithVariant = () => {
+  const options = ["1", "2", "3"]
+  const [values, setValues] = useState<string[]>([])
+
+  return (
+      <CheckboxGroup
+        label={"My Checkbox Group"}
+        values={values}
+        options={options}
+        id={"MyCheckboxGroup"}
+        onChange={setValues}
+        variant="alert"
+        checkedVariant="success"
+      />
+  )
+}

--- a/src/forms/__tests__/CheckboxGroup.test.tsx
+++ b/src/forms/__tests__/CheckboxGroup.test.tsx
@@ -1,0 +1,38 @@
+import { render, cleanup, screen, fireEvent } from "@testing-library/react"
+import CheckboxGroup from "forms/CheckboxGroup"
+
+afterEach(cleanup)
+
+describe("<CheckboxGroup>", () => {
+  it("displays the CheckboxGroup", () => {
+    const options = ["Option 1", "Option 2", "Option 3"]
+    let values: string[] = []
+    const setValues = jest.fn((newValues) => {
+      values = newValues
+    })
+
+    render(
+      <CheckboxGroup
+        id="MyCheckboxGroup"
+        testId="MyCheckboxGroup"
+        className="test-class"
+        options={options}
+        values={values}
+        onChange={setValues}
+      />
+    )
+    expect(screen.getByText(options[0])).toBeInTheDocument()
+    expect(screen.getByText(options[1])).toBeInTheDocument()
+    expect(screen.getByText(options[2])).toBeInTheDocument()
+
+    expect(screen.getByTestId("MyCheckboxGroup")).not.toBeNull()
+    expect(screen.getByTestId("MyCheckboxGroup")).toHaveClass("test-class")
+
+    const checkboxOne = screen.getByRole("checkbox", { name: /Option 1/i })
+    expect((checkboxOne as HTMLInputElement).checked).toBe(false)
+
+    fireEvent.click(checkboxOne)
+    expect(setValues).toHaveBeenCalledWith(["Option 1"])
+    expect(values).toEqual(["Option 1"])
+  })
+})


### PR DESCRIPTION
## Issue Overview

This PR addresses: https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/512

## Description
Adds a CheckboxGroup component to seeds. This component is a group of checkbox inputs. Currently, each of these inputs are styled using the `Button.scss` classes. 

## How Can This Be Tested/Reviewed?
- Run storybook
- Go to CheckboxGroup
- Compare to desired Doorway designs linked in ticket
- Ensure tests run successfully

## Checklist:

- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
