### PR TITLE
fix: update fallback focus on overlay

### DIFF
--- a/src/overlays/Overlay.tsx
+++ b/src/overlays/Overlay.tsx
@@ -121,6 +121,7 @@ const Overlay = (props: OverlayProps) => {
             focusTrapOptions={{
               allowOutsideClick: true,
               initialFocus: `#${props.ariaLabelledBy || uniqueFocusId}`,
+              fallbackFocus: `#${uniqueFocusId}`,
             }}
           >
             <div


### PR DESCRIPTION
Sets a fallback focus on our Overlay / Dialog components - tests fail without this, and it's a good thing to have on anyway for a11y in case the content doesn't load!