### PR TITLE
fix: dynamic height and width

### DIFF
--- a/src/overlays/Dialog.scss
+++ b/src/overlays/Dialog.scss
@@ -37,6 +37,7 @@
 
     margin-block-start: 0;
     max-height: 100vh;
+    max-height: 100dvh;
   }
 }
 

--- a/src/overlays/Drawer.scss
+++ b/src/overlays/Drawer.scss
@@ -29,11 +29,12 @@
   width: var(--drawer-width);
   max-width: 100%;
   height: 100vh;
-  
+  height: 100dvh;
+
   &.is-nested {
     width: calc(var(--drawer-width) - var(--drawer-nested-offset));
     max-width: calc(100% - var(--drawer-nested-offset));
-  
+
     @media (--sm-only) {
       --drawer-nested-offset: var(--seeds-s6);
     }

--- a/src/overlays/Overlay.scss
+++ b/src/overlays/Overlay.scss
@@ -4,7 +4,9 @@
   top: 0px;
   left: 0px;
   width: 100vw;
+  width: 100dvw;
   height: 100vh;
+  height: 100dvh;
   z-index: var(--seeds-z-index-overlay);
 }
 


### PR DESCRIPTION
## Issue Overview

This PR updates full-height and width UX to use dynamic viewport height / width, while still having the existing 100vh or 100vw as a backup. Without this, depending on the mobile browser you use, the URL box can overlap page content.
## Description

Example from Doorway production - I can't scroll down to the sticky footer.

<img src='https://github.com/user-attachments/assets/f29dab02-9c6e-4c18-bccb-42a7abdcdc0f' width='300'/>

## How Can This Be Tested/Reviewed?

I wasn't able to reproduce this in Storybook, but adding this in Doorway fixed it over there!

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
