### PR TITLE
fix: move to semantic tokens for bg colors

### DIFF
--- a/src/global/tokens/colors.scss
+++ b/src/global/tokens/colors.scss
@@ -156,8 +156,8 @@
   --seeds-bg-color-disabled: var(--seeds-color-gray-450);
   --seeds-bg-color-inverse: var(--seeds-color-gray-800);
   --seeds-bg-color-inverse-dark: var(--seeds-color-gray-950);
-  --seeds-bg-color-surface-primary: var(--seeds-color-blue-100);
-  --seeds-bg-color-surface-primary-inverse: var(--seeds-color-blue-900);
+  --seeds-bg-color-surface-primary: var(--seeds-color-primary-lighter);
+  --seeds-bg-color-surface-primary-inverse: var(--seeds-color-primary-darker);
 
   /* Border Color */
   --seeds-border-color: var(--seeds-color-gray-450);


### PR DESCRIPTION
## Description

We had two tokens where we were using core colors instead of semantic tokens.
This updates to use the semantic tokens.

## How Can This Be Tested/Reviewed?

The values didn't change in core.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
