### PR TITLE
fix: show button hover only on fine pointer devices

### DIFF
--- a/src/actions/Button.scss
+++ b/src/actions/Button.scss
@@ -54,9 +54,11 @@
     border-color: var(--seeds-color-primary);
     color: var(--seeds-color-on-inverse);
 
-    &:hover {
-      background-color: var(--seeds-color-primary-dark);
-      border-color: var(--seeds-color-primary-dark);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-primary-dark);
+        border-color: var(--seeds-color-primary-dark);
+      }
     }
   }
 
@@ -65,10 +67,12 @@
     border-color: var(--seeds-color-primary);
     color: var(--seeds-color-primary);
 
-    &:hover {
-      background-color: var(--seeds-color-primary-dark);
-      border-color: var(--seeds-color-primary-dark);
-      color: var(--seeds-color-on-inverse);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-primary-dark);
+        border-color: var(--seeds-color-primary-dark);
+        color: var(--seeds-color-on-inverse);
+      }
     }
   }
 
@@ -77,9 +81,11 @@
     border-color: var(--seeds-color-secondary);
     color: var(--seeds-color-on-inverse);
 
-    &:hover {
-      background-color: var(--seeds-color-secondary-dark);
-      border-color: var(--seeds-color-secondary-dark);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-secondary-dark);
+        border-color: var(--seeds-color-secondary-dark);
+      }
     }
   }
 
@@ -88,10 +94,12 @@
     border-color: var(--seeds-color-secondary);
     color: var(--seeds-color-secondary);
 
-    &:hover {
-      background-color: var(--seeds-color-secondary-dark);
-      border-color: var(--seeds-color-secondary-dark);
-      color: var(--seeds-color-on-inverse);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-secondary-dark);
+        border-color: var(--seeds-color-secondary-dark);
+        color: var(--seeds-color-on-inverse);
+      }
     }
   }
 
@@ -100,9 +108,11 @@
     border-color: var(--seeds-color-success);
     color: var(--seeds-color-on-inverse);
 
-    &:hover {
-      background-color: var(--seeds-color-success-dark);
-      border-color: var(--seeds-color-success-dark);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-success-dark);
+        border-color: var(--seeds-color-success-dark);
+      }
     }
   }
 
@@ -111,10 +121,12 @@
     border-color: var(--seeds-color-success);
     color: var(--seeds-color-success);
 
-    &:hover {
-      background-color: var(--seeds-color-success-dark);
-      border-color: var(--seeds-color-success-dark);
-      color: var(--seeds-color-on-inverse);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-success-dark);
+        border-color: var(--seeds-color-success-dark);
+        color: var(--seeds-color-on-inverse);
+      }
     }
   }
 
@@ -123,9 +135,11 @@
     border-color: var(--seeds-color-alert);
     color: var(--seeds-color-on-inverse);
 
-    &:hover {
-      background-color: var(--seeds-color-alert-dark);
-      border-color: var(--seeds-color-alert-dark);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-alert-dark);
+        border-color: var(--seeds-color-alert-dark);
+      }
     }
   }
 
@@ -134,10 +148,12 @@
     border-color: var(--seeds-color-alert);
     color: var(--seeds-color-alert);
 
-    &:hover {
-      background-color: var(--seeds-color-alert-dark);
-      border-color: var(--seeds-color-alert-dark);
-      color: var(--seeds-color-on-inverse);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-alert-dark);
+        border-color: var(--seeds-color-alert-dark);
+        color: var(--seeds-color-on-inverse);
+      }
     }
   }
 
@@ -146,9 +162,11 @@
     border-color: var(--seeds-color-warn);
     color: var(--seeds-color-secondary-darker);
 
-    &:hover {
-      background-color: var(--seeds-color-warn-dark);
-      border-color: var(--seeds-color-warn-dark);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-warn-dark);
+        border-color: var(--seeds-color-warn-dark);
+      }
     }
   }
 
@@ -157,9 +175,11 @@
     border-color: var(--seeds-color-warn);
     color: var(--seeds-color-secondary-darker);
 
-    &:hover {
-      background-color: var(--seeds-color-warn-dark);
-      border-color: var(--seeds-color-warn-dark);
+    @media (any-pointer: fine) {
+      &:hover {
+        background-color: var(--seeds-color-warn-dark);
+        border-color: var(--seeds-color-warn-dark);
+      }
     }
   }
 


### PR DESCRIPTION
## Issue Overview

This PR addresses #109

## Description

In essence we want the button hover state only when fine pointers are used (aka a mouse cursor, but also a stylus with hovering support like Apple Pencil).

## How Can This Be Tested/Reviewed?

Verify that when you're using touchscreen devices, there's no hover state activated for a button upon tap. But hover still works when using a mouse or stylus.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
