### PR TITLE
docs: video dialog story

### DIFF
--- a/src/overlays/__stories__/Dialog.stories.tsx
+++ b/src/overlays/__stories__/Dialog.stories.tsx
@@ -100,3 +100,44 @@ export const OverflowingContent = () => {
     </>
   )
 }
+
+export const FullWidthVideo = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  return (
+    <>
+      <button onClick={() => setIsOpen(!isOpen)}>Toggle Dialog</button>
+      <Dialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        ariaLabelledBy="video"
+        ariaDescribedBy="video-details"
+        className={"custom-class-dialog"}
+      >
+        <Dialog.Header id="conf">Video dialog</Dialog.Header>
+        <Dialog.Content id="video-details">
+          <div className={"custom-class-video-wrapper"}>
+            <iframe
+              title={"Label"}
+              src={"https://www.youtube.com/embed/UF3d34a6kqg?si=-uP6h3edIPS2INQE"}
+              allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen
+              className={"custom-class-video"}
+            />
+          </div>
+        </Dialog.Content>
+      </Dialog>
+      <style>
+        {
+          ".custom-class-dialog {  --overlay-padding: 0; --overlay-border-color: none; --dialog-width: var(--seeds-width-3xl); }"
+        }
+      </style>
+      <style>
+        {
+          ".custom-class-video-wrapper { aspect-ratio: 16 / 9; height: calc(100% - var(--seeds-s0_5));}"
+        }
+      </style>
+      <style>{".custom-class-video { width: 100%; height: 100%; border: 0;}"}</style>
+    </>
+  )
+}

--- a/src/overlays/__stories__/Dialog.stories.tsx
+++ b/src/overlays/__stories__/Dialog.stories.tsx
@@ -114,7 +114,7 @@ export const FullWidthVideo = () => {
         className={"custom-class-dialog"}
       >
         <Dialog.Header id="video">Video dialog</Dialog.Header>
-        <Dialog.Content id="video-details">
+        <Dialog.Content id="video-details" className={"custom-class-video-content"}>
           <div className={"custom-class-video-wrapper"}>
             <iframe
               title={"Label"}
@@ -132,9 +132,10 @@ export const FullWidthVideo = () => {
           ".custom-class-dialog {  --overlay-padding: 0; --overlay-border-color: none; --dialog-width: var(--seeds-width-3xl); }"
         }
       </style>
+      <style>{".custom-class-video-content { height: 100%; display: contents;}"}</style>
       <style>
         {
-          ".custom-class-video-wrapper { aspect-ratio: 16 / 9; height: calc(100% - var(--seeds-s0_5)); overflow: hidden;}"
+          ".custom-class-video-wrapper { aspect-ratio: 16 / 9 auto; width: 100%; overflow: hidden; max-height: 80vh;}"
         }
       </style>
       <style>{".custom-class-video { width: 100%; height: 100%; border: 0;}"}</style>

--- a/src/overlays/__stories__/Dialog.stories.tsx
+++ b/src/overlays/__stories__/Dialog.stories.tsx
@@ -113,7 +113,7 @@ export const FullWidthVideo = () => {
         ariaDescribedBy="video-details"
         className={"custom-class-dialog"}
       >
-        <Dialog.Header id="conf">Video dialog</Dialog.Header>
+        <Dialog.Header id="video">Video dialog</Dialog.Header>
         <Dialog.Content id="video-details">
           <div className={"custom-class-video-wrapper"}>
             <iframe

--- a/src/overlays/__stories__/Dialog.stories.tsx
+++ b/src/overlays/__stories__/Dialog.stories.tsx
@@ -132,13 +132,11 @@ export const FullWidthVideo = () => {
           ".custom-class-dialog {  --overlay-padding: 0; --overlay-border-color: none; --dialog-width: var(--seeds-width-3xl); }"
         }
       </style>
-      <style>{".custom-class-video-content { height: 100%; display: contents;}"}</style>
+      <style>{".custom-class-video-content { display: contents; }"}</style>
       <style>
-        {
-          ".custom-class-video-wrapper { aspect-ratio: 16 / 9 auto; width: 100%; overflow: hidden; max-height: 80vh;}"
-        }
+        {".custom-class-video-wrapper { aspect-ratio: 16 / 9 auto; overflow: hidden; }"}
       </style>
-      <style>{".custom-class-video { width: 100%; height: 100%; border: 0;}"}</style>
+      <style>{".custom-class-video { width: 100%; height: 100%; border: 0; }"}</style>
     </>
   )
 }

--- a/src/overlays/__stories__/Dialog.stories.tsx
+++ b/src/overlays/__stories__/Dialog.stories.tsx
@@ -134,7 +134,7 @@ export const FullWidthVideo = () => {
       </style>
       <style>
         {
-          ".custom-class-video-wrapper { aspect-ratio: 16 / 9; height: calc(100% - var(--seeds-s0_5));}"
+          ".custom-class-video-wrapper { aspect-ratio: 16 / 9; height: calc(100% - var(--seeds-s0_5)); overflow: hidden;}"
         }
       </style>
       <style>{".custom-class-video { width: 100%; height: 100%; border: 0;}"}</style>


### PR DESCRIPTION
## Description

Adds [an additional story to the Dialog component](https://deploy-preview-112--storybook-ui-seeds.netlify.app/?path=/story/overlays-dialog--full-width-video) to demonstrate how to support a full width video. We need this behavior [in Detroit](https://homeconnect.detroitmi.gov/housing-basics).

## How Can This Be Tested/Reviewed?

Check out the story! The styles and overrides added are visible in the code sample below the story.

If there's a preference to have this be a flag on the modal, where you can pass in a video URL and it just does this - lmk!

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
