### PR TITLE
fix: lower font weight for unselected tab

### DIFF
--- a/src/navigation/Tabs.scss
+++ b/src/navigation/Tabs.scss
@@ -92,6 +92,10 @@
     color: var(--tab-active-label-color);
   }
 
+  &[aria-selected="false"] {
+    font-weight: var(--seeds-font-weight-regular);
+  }
+
   &[aria-disabled="true"] {
     color: var(--seeds-text-color-disabled);
     border-block-end-width: var(--tab-border-width);


### PR DESCRIPTION
## Description

This PR lowers the font weight for unselected tabs to more closely match the latest [designs](https://www.figma.com/design/xqyamlgdsASkLTYlcifBwq/core-patterns?node-id=2133-50445&m=dev).

## How Can This Be Tested/Reviewed?

You can check out the [Tabs stories](https://deploy-preview-116--storybook-ui-seeds.netlify.app/?path=/story/navigation-tabs--default).

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
