### PR TITLE
feat: upgrading focus-trap-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "focus-trap-react": "^10.2.1",
+    "focus-trap-react": "^11.0.3",
     "markdown-to-jsx": "^6.11.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/overlays/Overlay.tsx
+++ b/src/overlays/Overlay.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useId } from "react"
+import React, { useRef, useId } from "react"
 import { createPortal } from "react-dom"
-import FocusTrap from "focus-trap-react"
+import { FocusTrap } from "focus-trap-react"
 import { XMarkIcon } from "@heroicons/react/20/solid"
 import Icon from "../icons/Icon"
 import Heading from "../text/Heading"
@@ -137,7 +137,7 @@ const Overlay = (props: OverlayProps) => {
             </div>
           </FocusTrap>
         </div>,
-        overlayPortalEl.current
+        overlayPortalEl.current,
       )
     : null
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6143,18 +6143,18 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-focus-trap-react@^10.2.1:
-  version "10.2.1"
-  resolved "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.2.1.tgz"
-  integrity sha512-UrAKOn52lvfHF6lkUMfFhlQxFgahyNW5i6FpHWkDxAeD4FSk3iwx9n4UEA4Sims0G5WiGIi0fAyoq3/UVeNCYA==
+focus-trap-react@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-11.0.3.tgz#fe46bbe2a024379b3783cad73187197bafbadb88"
+  integrity sha512-tS1+enWS/gwCHk2WIF3KpM2oz7Y3HsnRImzHZNRgCBLWXzNG4XQVlJgbqdLr4lBKRXGdDBjQYitSh1bf2xe4Ag==
   dependencies:
-    focus-trap "^7.5.2"
+    focus-trap "^7.6.4"
     tabbable "^6.2.0"
 
-focus-trap@^7.5.2:
-  version "7.5.2"
-  resolved "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz"
-  integrity sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==
+focus-trap@^7.6.4:
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.6.4.tgz#455ec5c51fee5ae99604ca15142409ffbbf84db9"
+  integrity sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==
   dependencies:
     tabbable "^6.2.0"
 


### PR DESCRIPTION
This PR addresses part of https://github.com/bloom-housing/bloom/issues/4777

## Description
This upgrades the focus-trap-react package and the overlay component with some minor tweaks

Attempting to upgrade nextjs required this package get upgraded so upgraded it now is

## How Can This Be Tested/Reviewed?
you should be able to stand this up locally and look around the overlay components and see that they are exactly the same as they were before

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [x] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
