### PR TITLE
fix: CommonMessage mobile screen reader accessibility

### DIFF
--- a/src/blocks/shared/CommonMessage.tsx
+++ b/src/blocks/shared/CommonMessage.tsx
@@ -68,7 +68,7 @@ const CommonMessage = forwardRef(
     const variant = props.variant || "primary"
     const VariantIcon = CommonMessageIconMap[variant]
 
-    return props.children ? (
+    return (
       <div
         ref={ref}
         id={props.id}
@@ -88,7 +88,9 @@ const CommonMessage = forwardRef(
                 </Icon>
               )}
         </span>
-        <span data-part="content">{props.children}</span>
+        <span data-part="content">
+          {props.children || null}
+        </span>
         {props.closeable && (
           <button
             aria-label="Close"
@@ -106,17 +108,7 @@ const CommonMessage = forwardRef(
           </button>
         )}
       </div>
-    ) : <div
-          ref={ref}
-          id={props.id}
-          className={classNames.join(" ")}
-          data-variant={variant}
-          hidden={visible === false}
-          role={props.role}
-          tabIndex={props.tabIndex}
-          data-testid={props.testId}
-        >
-        </div>
+    )
   },
 )
 


### PR DESCRIPTION
## Issue Overview

This PR addresses #114. 

## Description

In place of null, this PR changes the fallback for CommonMessage to create an empty div in the DOM so that it can be later populated by a mobile screen reader. This ensures that the alert message is announced. 

## How Can This Be Tested/Reviewed?

Even if there are no children, the component should hold an empty div position in the DOM. 

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
