### PR TITLE
fix: hide message entirely if no children

### DIFF
--- a/src/blocks/shared/CommonMessage.tsx
+++ b/src/blocks/shared/CommonMessage.tsx
@@ -68,6 +68,19 @@ const CommonMessage = forwardRef(
     const variant = props.variant || "primary"
     const VariantIcon = CommonMessageIconMap[variant]
 
+    if (!props.children) {
+      return (
+        <div
+          ref={ref}
+          id={props.id}
+          hidden={visible === false}
+          role={props.role}
+          tabIndex={props.tabIndex}
+          data-testid={props.testId}
+        />
+      )
+    }
+
     return (
       <div
         ref={ref}
@@ -88,9 +101,7 @@ const CommonMessage = forwardRef(
                 </Icon>
               )}
         </span>
-        <span data-part="content">
-          {props.children || null}
-        </span>
+        <span data-part="content">{props.children}</span>
         {props.closeable && (
           <button
             aria-label="Close"


### PR DESCRIPTION
## Description

A followup for https://github.com/bloom-housing/ui-seeds/pull/122 
When there are no children, the message should visually hide altogether. This is the existing unwanted behavior:
![Screenshot 2025-05-28 at 4 44 28 PM](https://github.com/user-attachments/assets/8b2e3a5e-d5ce-45cd-a2d4-c956d2dfcef4)

## How Can This Be Tested/Reviewed?

I've since deleted it because I don't think we should publish it, but I created a story locally with a message with no children and ensured an empty div is rendered in the DOM.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
