### PR TITLE
fix!: grid role a11y fixes

### DIFF
--- a/src/forms/FieldValue.tsx
+++ b/src/forms/FieldValue.tsx
@@ -22,7 +22,7 @@ const FieldValue = (props: FieldValueProps) => {
   if (props.className) classNames.push(props.className)
 
   return (
-    <div id={props.id} className={classNames.join(" ")} role="gridcell" data-testid={props.testId}>
+    <div id={props.id} className={classNames.join(" ")} data-testid={props.testId}>
       {props.label && <p data-part="label">{props.label}</p>}
       <p data-part="value">{props.children}</p>
       {props.helpText && <p data-part="help-text">{props.helpText}</p>}

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -6,6 +6,7 @@ export interface GridCellProps {
   children: React.ReactNode
   id?: string
   className?: string
+  roles?: boolean
 }
 
 const GridCell = (props: GridCellProps) => {
@@ -13,7 +14,7 @@ const GridCell = (props: GridCellProps) => {
   if (props.className) classNames.push(props.className)
 
   return (
-    <div id={props.id} className={classNames.join(" ")} role="gridcell">
+    <div id={props.id} className={classNames.join(" ")} role={props.roles ? "gridcell" : ""}>
       {props.children}
     </div>
   )
@@ -28,7 +29,12 @@ const GridRow = (props: GridRowProps) => {
   if (props.className) classNames.push(props.className)
 
   return (
-    <div id={props.id} className={classNames.join(" ")} role="row" data-columns={props.columns}>
+    <div
+      id={props.id}
+      className={classNames.join(" ")}
+      role={props.roles ? "row" : ""}
+      data-columns={props.columns}
+    >
       {props.children}
     </div>
   )
@@ -49,7 +55,12 @@ const Grid = (props: GridProps) => {
   if (props.className) classNames.push(props.className)
 
   return (
-    <div id={props.id} className={classNames.join(" ")} data-spacing={props.spacing} role="grid">
+    <div
+      id={props.id}
+      className={classNames.join(" ")}
+      data-spacing={props.spacing}
+      role={props.roles ? "grid" : ""}
+    >
       {props.children}
     </div>
   )

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -12,7 +12,6 @@ export interface GridCellProps {
   children: React.ReactNode
   id?: string
   className?: string
-  roles?: boolean
 }
 
 const GridCell = (props: GridCellProps) => {
@@ -51,6 +50,11 @@ const GridRow = (props: GridRowProps) => {
 export type GridSpacing = Extract<SeedsSizes, "sm" | "md" | "lg" | "xl">
 
 export interface GridProps extends GridCellProps {
+  /**
+   * If true, adds grid, row, and gridcell roles to each component. Only recommended for use where the grid itself is a primary interactive widget, such as a data grid or a spreadsheet-like interface - not just for displaying data that happens to be visually arranged in a grid
+   * @default md
+   */
+  roles?: boolean
   /**
    * Control the gap between grid cells
    * @default md

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -1,6 +1,12 @@
-import React from "react"
+import React, { createContext, useContext } from "react"
 import { SeedsSizes } from "../global/sharedTypes"
 import "./Grid.scss"
+
+interface GridContextType {
+  roles: boolean | undefined
+}
+
+const GridContext = createContext<GridContextType | null>(null)
 
 export interface GridCellProps {
   children: React.ReactNode
@@ -13,8 +19,9 @@ const GridCell = (props: GridCellProps) => {
   const classNames = ["seeds-grid-cell"]
   if (props.className) classNames.push(props.className)
 
+  const context = useContext(GridContext)
   return (
-    <div id={props.id} className={classNames.join(" ")} role={props.roles ? "gridcell" : ""}>
+    <div id={props.id} className={classNames.join(" ")} role={context?.roles ? "gridcell" : ""}>
       {props.children}
     </div>
   )
@@ -28,11 +35,12 @@ const GridRow = (props: GridRowProps) => {
   const classNames = ["seeds-grid-row"]
   if (props.className) classNames.push(props.className)
 
+  const context = useContext(GridContext)
   return (
     <div
       id={props.id}
       className={classNames.join(" ")}
-      role={props.roles ? "row" : ""}
+      role={context?.roles ? "row" : ""}
       data-columns={props.columns}
     >
       {props.children}
@@ -55,14 +63,16 @@ const Grid = (props: GridProps) => {
   if (props.className) classNames.push(props.className)
 
   return (
-    <div
-      id={props.id}
-      className={classNames.join(" ")}
-      data-spacing={props.spacing}
-      role={props.roles ? "grid" : ""}
-    >
-      {props.children}
-    </div>
+    <GridContext.Provider value={{ roles: props.roles }}>
+      <div
+        id={props.id}
+        className={classNames.join(" ")}
+        data-spacing={props.spacing}
+        role={props.roles ? "grid" : ""}
+      >
+        {props.children}
+      </div>
+    </GridContext.Provider>
   )
 }
 

--- a/src/layout/__stories__/Grid.stories.tsx
+++ b/src/layout/__stories__/Grid.stories.tsx
@@ -26,54 +26,58 @@ export const GridExample = () => (
   <>
     <Heading size="xl">Three Columns:</Heading>
 
-    <Grid spacing="lg">
-      <Grid.Row columns={3}>
-        <Grid.Cell>Cell 1</Grid.Cell>
-        <Grid.Cell>Cell 2</Grid.Cell>
-        <Grid.Cell>Cell 3</Grid.Cell>
-        <Grid.Cell>Cell 4</Grid.Cell>
-        <Grid.Cell>Cell 5</Grid.Cell>
-        <Grid.Cell>Cell 6</Grid.Cell>
+    <Grid spacing="lg" roles>
+      <Grid.Row columns={3} roles>
+        <Grid.Cell roles>Cell 1</Grid.Cell>
+        <Grid.Cell roles>Cell 2</Grid.Cell>
+        <Grid.Cell roles>Cell 3</Grid.Cell>
+        <Grid.Cell roles>Cell 4</Grid.Cell>
+        <Grid.Cell roles>Cell 5</Grid.Cell>
+        <Grid.Cell roles>Cell 6</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Four Columns:</Heading>
 
-    <Grid spacing="lg">
-      <Grid.Row columns={4}>
-        <Grid.Cell>Cell 1</Grid.Cell>
-        <Grid.Cell>Cell 2</Grid.Cell>
-        <Grid.Cell>Cell 3</Grid.Cell>
-        <Grid.Cell>Cell 4</Grid.Cell>
+    <Grid spacing="lg" roles>
+      <Grid.Row columns={4} roles>
+        <Grid.Cell roles>Cell 1</Grid.Cell>
+        <Grid.Cell roles>Cell 2</Grid.Cell>
+        <Grid.Cell roles>Cell 3</Grid.Cell>
+        <Grid.Cell roles>Cell 4</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Two Columns:</Heading>
 
-    <Grid spacing="lg">
-      <Grid.Row>
-        <Grid.Cell>Cell 1</Grid.Cell>
-        <Grid.Cell>Cell 2</Grid.Cell>
+    <Grid spacing="lg" roles>
+      <Grid.Row roles>
+        <Grid.Cell roles>Cell 1</Grid.Cell>
+        <Grid.Cell roles>Cell 2</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">One Column + Two Columns:</Heading>
 
-    <Grid spacing="lg">
-      <Grid.Row columns="4">
-        <Grid.Cell className="seeds-grid-span-2">Cell 1 (Long)</Grid.Cell>
-        <Grid.Cell>Cell 2</Grid.Cell>
-        <Grid.Cell>Cell 3</Grid.Cell>
+    <Grid spacing="lg" roles>
+      <Grid.Row columns="4" roles>
+        <Grid.Cell className="seeds-grid-span-2" roles>
+          Cell 1 (Long)
+        </Grid.Cell>
+        <Grid.Cell roles>Cell 2</Grid.Cell>
+        <Grid.Cell roles>Cell 3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Two Columns + One Column:</Heading>
 
-    <Grid spacing="lg">
-      <Grid.Row columns="4">
-        <Grid.Cell>Cell 1</Grid.Cell>
-        <Grid.Cell>Cell 2</Grid.Cell>
-        <Grid.Cell className="seeds-grid-span-2">Cell 3 (Long)</Grid.Cell>
+    <Grid spacing="lg" roles>
+      <Grid.Row columns="4" roles>
+        <Grid.Cell roles>Cell 1</Grid.Cell>
+        <Grid.Cell roles>Cell 2</Grid.Cell>
+        <Grid.Cell className="seeds-grid-span-2" roles>
+          Cell 3 (Long)
+        </Grid.Cell>
       </Grid.Row>
     </Grid>
     <StoryStyles />
@@ -84,41 +88,41 @@ export const gridSpacings = () => (
   <>
     <Heading size="xl">Small Spacing</Heading>
 
-    <Grid spacing="sm">
-      <Grid.Row>
-        <Grid.Cell>1</Grid.Cell>
-        <Grid.Cell>2</Grid.Cell>
-        <Grid.Cell>3</Grid.Cell>
+    <Grid spacing="sm" roles>
+      <Grid.Row roles>
+        <Grid.Cell roles>1</Grid.Cell>
+        <Grid.Cell roles>2</Grid.Cell>
+        <Grid.Cell roles>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Medium (Default) Spacing</Heading>
 
-    <Grid spacing="md">
-      <Grid.Row>
-        <Grid.Cell>1</Grid.Cell>
-        <Grid.Cell>2</Grid.Cell>
-        <Grid.Cell>3</Grid.Cell>
+    <Grid spacing="md" roles>
+      <Grid.Row roles>
+        <Grid.Cell roles>1</Grid.Cell>
+        <Grid.Cell roles>2</Grid.Cell>
+        <Grid.Cell roles>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Large Spacing</Heading>
 
-    <Grid spacing="lg">
-      <Grid.Row>
-        <Grid.Cell>1</Grid.Cell>
-        <Grid.Cell>2</Grid.Cell>
-        <Grid.Cell>3</Grid.Cell>
+    <Grid spacing="lg" roles>
+      <Grid.Row roles>
+        <Grid.Cell roles>1</Grid.Cell>
+        <Grid.Cell roles>2</Grid.Cell>
+        <Grid.Cell roles>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Extra Large Spacing</Heading>
 
-    <Grid spacing="xl">
-      <Grid.Row>
-        <Grid.Cell>1</Grid.Cell>
-        <Grid.Cell>2</Grid.Cell>
-        <Grid.Cell>3</Grid.Cell>
+    <Grid spacing="xl" roles>
+      <Grid.Row roles>
+        <Grid.Cell roles>1</Grid.Cell>
+        <Grid.Cell roles>2</Grid.Cell>
+        <Grid.Cell roles>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
@@ -128,23 +132,23 @@ export const gridSpacings = () => (
 
 export const differentColumnCounts = () => (
   <>
-    <Grid>
-      <Grid.Row>
-        <Grid.Cell>1</Grid.Cell>
-        <Grid.Cell>2</Grid.Cell>
-        <Grid.Cell>3</Grid.Cell>
+    <Grid roles>
+      <Grid.Row roles>
+        <Grid.Cell roles>1</Grid.Cell>
+        <Grid.Cell roles>2</Grid.Cell>
+        <Grid.Cell roles>3</Grid.Cell>
       </Grid.Row>
 
       <Grid.Row>
-        <Grid.Cell>4</Grid.Cell>
-        <Grid.Cell>5</Grid.Cell>
+        <Grid.Cell roles>4</Grid.Cell>
+        <Grid.Cell roles>5</Grid.Cell>
       </Grid.Row>
 
       <Grid.Row>
-        <Grid.Cell>6</Grid.Cell>
-        <Grid.Cell>7</Grid.Cell>
-        <Grid.Cell>8</Grid.Cell>
-        <Grid.Cell>9</Grid.Cell>
+        <Grid.Cell roles>6</Grid.Cell>
+        <Grid.Cell roles>7</Grid.Cell>
+        <Grid.Cell roles>8</Grid.Cell>
+        <Grid.Cell roles>9</Grid.Cell>
       </Grid.Row>
     </Grid>
 
@@ -156,15 +160,56 @@ export const sectionsAndFieldValues = () => (
   <>
     <section>
       <Heading size="xl">Field Values</Heading>
+      <Grid spacing="md" roles>
+        <Grid.Row roles>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+        </Grid.Row>
+        <Grid.Row roles>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+        </Grid.Row>
+      </Grid>
+    </section>
+
+    <StoryStyles />
+  </>
+)
+
+export const noRolesOnlyLayout = () => (
+  <>
+    <section>
+      <Heading size="xl">Field Values</Heading>
       <Grid spacing="md">
         <Grid.Row>
-          <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          <Grid.Cell>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
         </Grid.Row>
         <Grid.Row>
-          <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          <Grid.Cell>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
         </Grid.Row>
       </Grid>
     </section>

--- a/src/layout/__stories__/Grid.stories.tsx
+++ b/src/layout/__stories__/Grid.stories.tsx
@@ -188,22 +188,22 @@ export const includeGridRoles = () => (
     <section>
       <Heading size="xl">Field Values</Heading>
       <Grid spacing="md" roles>
-        <Grid.Row roles>
-          <Grid.Cell roles>
+        <Grid.Row>
+          <Grid.Cell>
             <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
           </Grid.Cell>
-          <Grid.Cell roles>
+          <Grid.Cell>
             <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
           </Grid.Cell>
-          <Grid.Cell roles>
+          <Grid.Cell>
             <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
           </Grid.Cell>
         </Grid.Row>
-        <Grid.Row roles>
-          <Grid.Cell roles>
+        <Grid.Row>
+          <Grid.Cell>
             <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
           </Grid.Cell>
-          <Grid.Cell roles>
+          <Grid.Cell>
             <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
           </Grid.Cell>
         </Grid.Row>

--- a/src/layout/__stories__/Grid.stories.tsx
+++ b/src/layout/__stories__/Grid.stories.tsx
@@ -26,58 +26,54 @@ export const GridExample = () => (
   <>
     <Heading size="xl">Three Columns:</Heading>
 
-    <Grid spacing="lg" roles>
-      <Grid.Row columns={3} roles>
-        <Grid.Cell roles>Cell 1</Grid.Cell>
-        <Grid.Cell roles>Cell 2</Grid.Cell>
-        <Grid.Cell roles>Cell 3</Grid.Cell>
-        <Grid.Cell roles>Cell 4</Grid.Cell>
-        <Grid.Cell roles>Cell 5</Grid.Cell>
-        <Grid.Cell roles>Cell 6</Grid.Cell>
+    <Grid spacing="lg">
+      <Grid.Row columns={3}>
+        <Grid.Cell>Cell 1</Grid.Cell>
+        <Grid.Cell>Cell 2</Grid.Cell>
+        <Grid.Cell>Cell 3</Grid.Cell>
+        <Grid.Cell>Cell 4</Grid.Cell>
+        <Grid.Cell>Cell 5</Grid.Cell>
+        <Grid.Cell>Cell 6</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Four Columns:</Heading>
 
-    <Grid spacing="lg" roles>
-      <Grid.Row columns={4} roles>
-        <Grid.Cell roles>Cell 1</Grid.Cell>
-        <Grid.Cell roles>Cell 2</Grid.Cell>
-        <Grid.Cell roles>Cell 3</Grid.Cell>
-        <Grid.Cell roles>Cell 4</Grid.Cell>
+    <Grid spacing="lg">
+      <Grid.Row columns={4}>
+        <Grid.Cell>Cell 1</Grid.Cell>
+        <Grid.Cell>Cell 2</Grid.Cell>
+        <Grid.Cell>Cell 3</Grid.Cell>
+        <Grid.Cell>Cell 4</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Two Columns:</Heading>
 
-    <Grid spacing="lg" roles>
-      <Grid.Row roles>
-        <Grid.Cell roles>Cell 1</Grid.Cell>
-        <Grid.Cell roles>Cell 2</Grid.Cell>
+    <Grid spacing="lg">
+      <Grid.Row>
+        <Grid.Cell>Cell 1</Grid.Cell>
+        <Grid.Cell>Cell 2</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">One Column + Two Columns:</Heading>
 
-    <Grid spacing="lg" roles>
-      <Grid.Row columns="4" roles>
-        <Grid.Cell className="seeds-grid-span-2" roles>
-          Cell 1 (Long)
-        </Grid.Cell>
-        <Grid.Cell roles>Cell 2</Grid.Cell>
-        <Grid.Cell roles>Cell 3</Grid.Cell>
+    <Grid spacing="lg">
+      <Grid.Row columns="4">
+        <Grid.Cell className="seeds-grid-span-2">Cell 1 (Long)</Grid.Cell>
+        <Grid.Cell>Cell 2</Grid.Cell>
+        <Grid.Cell>Cell 3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Two Columns + One Column:</Heading>
 
-    <Grid spacing="lg" roles>
-      <Grid.Row columns="4" roles>
-        <Grid.Cell roles>Cell 1</Grid.Cell>
-        <Grid.Cell roles>Cell 2</Grid.Cell>
-        <Grid.Cell className="seeds-grid-span-2" roles>
-          Cell 3 (Long)
-        </Grid.Cell>
+    <Grid spacing="lg">
+      <Grid.Row columns="4">
+        <Grid.Cell>Cell 1</Grid.Cell>
+        <Grid.Cell>Cell 2</Grid.Cell>
+        <Grid.Cell className="seeds-grid-span-2">Cell 3 (Long)</Grid.Cell>
       </Grid.Row>
     </Grid>
     <StoryStyles />
@@ -88,41 +84,41 @@ export const gridSpacings = () => (
   <>
     <Heading size="xl">Small Spacing</Heading>
 
-    <Grid spacing="sm" roles>
-      <Grid.Row roles>
-        <Grid.Cell roles>1</Grid.Cell>
-        <Grid.Cell roles>2</Grid.Cell>
-        <Grid.Cell roles>3</Grid.Cell>
+    <Grid spacing="sm">
+      <Grid.Row>
+        <Grid.Cell>1</Grid.Cell>
+        <Grid.Cell>2</Grid.Cell>
+        <Grid.Cell>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Medium (Default) Spacing</Heading>
 
-    <Grid spacing="md" roles>
-      <Grid.Row roles>
-        <Grid.Cell roles>1</Grid.Cell>
-        <Grid.Cell roles>2</Grid.Cell>
-        <Grid.Cell roles>3</Grid.Cell>
+    <Grid spacing="md">
+      <Grid.Row>
+        <Grid.Cell>1</Grid.Cell>
+        <Grid.Cell>2</Grid.Cell>
+        <Grid.Cell>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Large Spacing</Heading>
 
-    <Grid spacing="lg" roles>
-      <Grid.Row roles>
-        <Grid.Cell roles>1</Grid.Cell>
-        <Grid.Cell roles>2</Grid.Cell>
-        <Grid.Cell roles>3</Grid.Cell>
+    <Grid spacing="lg">
+      <Grid.Row>
+        <Grid.Cell>1</Grid.Cell>
+        <Grid.Cell>2</Grid.Cell>
+        <Grid.Cell>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
     <Heading size="xl">Extra Large Spacing</Heading>
 
-    <Grid spacing="xl" roles>
-      <Grid.Row roles>
-        <Grid.Cell roles>1</Grid.Cell>
-        <Grid.Cell roles>2</Grid.Cell>
-        <Grid.Cell roles>3</Grid.Cell>
+    <Grid spacing="xl">
+      <Grid.Row>
+        <Grid.Cell>1</Grid.Cell>
+        <Grid.Cell>2</Grid.Cell>
+        <Grid.Cell>3</Grid.Cell>
       </Grid.Row>
     </Grid>
 
@@ -132,23 +128,23 @@ export const gridSpacings = () => (
 
 export const differentColumnCounts = () => (
   <>
-    <Grid roles>
-      <Grid.Row roles>
-        <Grid.Cell roles>1</Grid.Cell>
-        <Grid.Cell roles>2</Grid.Cell>
-        <Grid.Cell roles>3</Grid.Cell>
+    <Grid>
+      <Grid.Row>
+        <Grid.Cell>1</Grid.Cell>
+        <Grid.Cell>2</Grid.Cell>
+        <Grid.Cell>3</Grid.Cell>
       </Grid.Row>
 
       <Grid.Row>
-        <Grid.Cell roles>4</Grid.Cell>
-        <Grid.Cell roles>5</Grid.Cell>
+        <Grid.Cell>4</Grid.Cell>
+        <Grid.Cell>5</Grid.Cell>
       </Grid.Row>
 
       <Grid.Row>
-        <Grid.Cell roles>6</Grid.Cell>
-        <Grid.Cell roles>7</Grid.Cell>
-        <Grid.Cell roles>8</Grid.Cell>
-        <Grid.Cell roles>9</Grid.Cell>
+        <Grid.Cell>6</Grid.Cell>
+        <Grid.Cell>7</Grid.Cell>
+        <Grid.Cell>8</Grid.Cell>
+        <Grid.Cell>9</Grid.Cell>
       </Grid.Row>
     </Grid>
 
@@ -157,37 +153,6 @@ export const differentColumnCounts = () => (
 )
 
 export const sectionsAndFieldValues = () => (
-  <>
-    <section>
-      <Heading size="xl">Field Values</Heading>
-      <Grid spacing="md" roles>
-        <Grid.Row roles>
-          <Grid.Cell roles>
-            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          </Grid.Cell>
-          <Grid.Cell roles>
-            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          </Grid.Cell>
-          <Grid.Cell roles>
-            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          </Grid.Cell>
-        </Grid.Row>
-        <Grid.Row roles>
-          <Grid.Cell roles>
-            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          </Grid.Cell>
-          <Grid.Cell roles>
-            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
-          </Grid.Cell>
-        </Grid.Row>
-      </Grid>
-    </section>
-
-    <StoryStyles />
-  </>
-)
-
-export const noRolesOnlyLayout = () => (
   <>
     <section>
       <Heading size="xl">Field Values</Heading>
@@ -208,6 +173,37 @@ export const noRolesOnlyLayout = () => (
             <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
           </Grid.Cell>
           <Grid.Cell>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+        </Grid.Row>
+      </Grid>
+    </section>
+
+    <StoryStyles />
+  </>
+)
+
+export const includeGridRoles = () => (
+  <>
+    <section>
+      <Heading size="xl">Field Values</Heading>
+      <Grid spacing="md" roles>
+        <Grid.Row roles>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+        </Grid.Row>
+        <Grid.Row roles>
+          <Grid.Cell roles>
+            <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
+          </Grid.Cell>
+          <Grid.Cell roles>
             <FieldValue label="Property Amenities">Pool, BBQ, Rooftop View</FieldValue>
           </Grid.Cell>
         </Grid.Row>


### PR DESCRIPTION
## Issue Overview

Related to: https://github.com/bloom-housing/bloom/pull/5138

## Description

This PR fixes some a11y issues with the grid + related components. The way we're using our Grids causes page data to often read very strangely compared to what we're intending. It reads form fields and detail views with lots of extra and unhelpful information about rows and columns, but that information is actually not relevant to the data on the screen for any of our use cases. In research I'm also seeing `The grid role is best suited for applications where the grid itself is a primary interactive widget, such as a data grid or a spreadsheet-like interface, not just for displaying data that happens to be visually arranged in a grid.`

Because of this, I have made the default behavior of the Grid component to be not including the roles that would make it read to a screen reader as a grid, because I don't think we have any of those use cases right now. You can still add the roles prop to make it an accessible grid if needed.

This is a breaking change.

## How Can This Be Tested/Reviewed?

You can compare the screen reader experiences between the [story with the grid roles](https://deploy-preview-125--storybook-ui-seeds.netlify.app/?path=/story/layout-grid--include-grid-roles) (prod experience now) and the [story without](https://deploy-preview-125--storybook-ui-seeds.netlify.app/?path=/story/layout-grid--sections-and-field-values). Here is a video of me doing that:

https://github.com/user-attachments/assets/39a5f236-b04a-4953-9f6a-d33cf7e859bf



## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
