### PR TITLE
fix: add heading id and tab index for HeadingGroup

### DIFF
--- a/src/text/HeadingGroup.tsx
+++ b/src/text/HeadingGroup.tsx
@@ -12,6 +12,10 @@ export interface HeadingGroupProps extends Pick<HeadingProps, "size"> {
    * @default 2
    */
   headingPriority?: 1 | 2 | 3 | 4 | 5 | 6
+  /** Tab index for the heading element */
+  headingTabIndex?: number
+  /** ID of the heading element */
+  headingId?: string
   /** Element ID */
   id?: string
   /** Additional class name for the whole group */
@@ -24,7 +28,12 @@ const HeadingGroup = (props: HeadingGroupProps) => {
 
   return (
     <hgroup id={props.id} className={classNames.join(" ")} role="group">
-      <Heading priority={props.headingPriority ?? 2} size={props.size || "3xl"}>
+      <Heading
+        id={props.headingId}
+        priority={props.headingPriority ?? 2}
+        size={props.size || "3xl"}
+        tabIndex={props.headingTabIndex}
+      >
         {props.heading}
       </Heading>
       <p>{props.subheading}</p>

--- a/src/text/HeadingGroup.tsx
+++ b/src/text/HeadingGroup.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import Heading, { HeadingProps } from "./Heading"
 import "./HeadingGroup.scss"
 
-export interface HeadingGroupProps extends Pick<HeadingProps, "size"> {
+export interface HeadingGroupProps {
   /** A string or element to display in an `h2` tag (overridable via `headingProps.priority`) */
   heading: React.ReactNode
   /** A string or element to display in a `p` tag */

--- a/src/text/HeadingGroup.tsx
+++ b/src/text/HeadingGroup.tsx
@@ -3,7 +3,7 @@ import Heading, { HeadingProps } from "./Heading"
 import "./HeadingGroup.scss"
 
 export interface HeadingGroupProps extends Pick<HeadingProps, "size"> {
-  /** A string or element to display in an `h2` tag (overridable via `headingPriority`) */
+  /** A string or element to display in an `h2` tag (overridable via `headingProps.priority`) */
   heading: React.ReactNode
   /** A string or element to display in a `p` tag */
   subheading: React.ReactNode
@@ -11,11 +11,7 @@ export interface HeadingGroupProps extends Pick<HeadingProps, "size"> {
    * The heading level (1 through 6)
    * @default 2
    */
-  headingPriority?: 1 | 2 | 3 | 4 | 5 | 6
-  /** Tab index for the heading element */
-  headingTabIndex?: number
-  /** ID of the heading element */
-  headingId?: string
+  headingProps?: HeadingProps
   /** Element ID */
   id?: string
   /** Additional class name for the whole group */
@@ -28,12 +24,7 @@ const HeadingGroup = (props: HeadingGroupProps) => {
 
   return (
     <hgroup id={props.id} className={classNames.join(" ")} role="group">
-      <Heading
-        id={props.headingId}
-        priority={props.headingPriority ?? 2}
-        size={props.size || "3xl"}
-        tabIndex={props.headingTabIndex}
-      >
+      <Heading priority={2} size={"3xl"} {...props.headingProps}>
         {props.heading}
       </Heading>
       <p>{props.subheading}</p>


### PR DESCRIPTION
## Issue Overview

This PR addresses [#4913](https://github.com/bloom-housing/bloom/issues/4913)

## Description

It's change needed for [this PR](https://github.com/bloom-housing/bloom/pull/5221) it will pass heading tab index and id from `HeadingGroup` to `Heading`

## How Can This Be Tested/Reviewed?
.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
