### PR TITLE
chore: improve tag padding & line height for multi-line text

### DIFF
--- a/src/text/Tag.scss
+++ b/src/text/Tag.scss
@@ -1,12 +1,13 @@
 .seeds-tag {
   --tag-border-radius: var(--seeds-rounded-full);
-  --tag-padding-inline: var(--seeds-s2_5);
-  --tag-padding-block: var(--seeds-s0_5);
+  --tag-padding-inline: var(--seeds-s3);
+  --tag-padding-block: var(--seeds-s1_5);
   --tag-interior-gap: var(--seeds-s1);
   --tag-font-size: var(--seeds-font-size-sm);
   --tag-font-size-lg: var(--seeds-font-size-base);
   --tag-font-weight: var(--seeds-font-weight-semibold);
   --tag-font-weight-lg: var(--seeds-font-weight-semibold);
+  --tag-line-height: var(--seeds-line-height-4);
 
   display: inline-flex;
   align-items: center;
@@ -16,6 +17,7 @@
   gap: var(--tag-interior-gap);
   font-size: var(--tag-font-size);
   font-weight: var(--tag-font-weight);
+  line-height: var(--tag-line-height);
 
   &[data-variant="primary"] {
     background-color: var(--seeds-color-primary-light);

--- a/src/text/__stories__/Tag.stories.tsx
+++ b/src/text/__stories__/Tag.stories.tsx
@@ -94,18 +94,34 @@ export const TagVariants = () => (
 )
 
 export const withIcons = () => (
-  <DocsIconWrapper>
-    <Tag>
-      <Icon>
-        <FaceSmileIcon />
-      </Icon>{" "}
-      Icon Left
-    </Tag>
-    <Tag>
-      Icon Right{" "}
-      <Icon>
-        <FaceSmileIcon />
-      </Icon>
-    </Tag>
-  </DocsIconWrapper>
+  <>
+    <DocsWrapper>
+      <DocsIconWrapper>
+        <Tag>
+          <Icon>
+            <FaceSmileIcon />
+          </Icon>{" "}
+          Icon Left
+        </Tag>
+        <Tag>
+          Icon Right{" "}
+          <Icon>
+            <FaceSmileIcon />
+          </Icon>
+        </Tag>
+      </DocsIconWrapper>
+    </DocsWrapper>
+    <DocsWrapper>
+      <Tag>
+        <span>
+          <Icon>
+            <FaceSmileIcon />
+          </Icon>{" "}
+          Very long tag text which
+          <br />
+          spans multiple lines
+        </span>
+      </Tag>
+    </DocsWrapper>
+  </>
 )


### PR DESCRIPTION
## Issue Overview

This PR addresses bloom-housing/bloom#5310

## Description

There were some bad visuals for tags when text wrapped to a second line, as shown in the issue. This PR adding slightly more padding while also adjusting the line height so tags look god with a single line and multiple lines.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
