### PR TITLE
fix: build issue

### DIFF
--- a/src/actions/__stories__/Button.stories.tsx
+++ b/src/actions/__stories__/Button.stories.tsx
@@ -28,7 +28,7 @@ const DocsRowWrapper = (props: React.PropsWithChildren) => {
 export const ButtonVariants = () => (
   <>
     <DocsWrapper>
-      <HeadingGroup size="2xl" heading="sm" subheading="Small Size" />
+      <HeadingGroup heading="sm" subheading="Small Size" headingProps={{ size: "2xl" }} />
       <div>
         <Button variant="primary" size="sm">
           Primary Small
@@ -71,7 +71,7 @@ export const ButtonVariants = () => (
       </div>
     </DocsWrapper>
     <DocsWrapper>
-      <HeadingGroup size="2xl" heading="md" subheading="Medium Size" />
+      <HeadingGroup heading="md" subheading="Medium Size" headingProps={{ size: "2xl" }} />
       <div>
         <Button variant="primary" size="md">
           Primary Medium
@@ -114,7 +114,7 @@ export const ButtonVariants = () => (
       </div>
     </DocsWrapper>
     <DocsWrapper>
-      <HeadingGroup size="2xl" heading="lg" subheading="Large Size" />
+      <HeadingGroup heading="lg" subheading="Large Size" headingProps={{ size: "2xl" }} />
       <div>
         <Button variant="primary" size="lg">
           Primary Large

--- a/src/blocks/__stories__/Card.stories.tsx
+++ b/src/blocks/__stories__/Card.stories.tsx
@@ -26,7 +26,11 @@ export const TextContent = () => (
   <DocsWrapper>
     <Card>
       <Card.Header>
-        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)" />
+        <HeadingGroup
+          heading="Wildflower"
+          subheading="Wildflower (or wild flower)"
+          headingProps={{ size: "2xl" }}
+        />
       </Card.Header>
 
       <Card.Section>
@@ -52,7 +56,11 @@ export const FlushDividers = () => (
   <DocsWrapper>
     <Card>
       <Card.Header divider="flush">
-        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)" />
+        <HeadingGroup
+          heading="Wildflower"
+          subheading="Wildflower (or wild flower)"
+          headingProps={{ size: "2xl" }}
+        />
       </Card.Header>
 
       <Card.Section divider="flush">
@@ -78,7 +86,11 @@ export const InsetDividers = () => (
   <DocsWrapper>
     <Card>
       <Card.Header divider="inset">
-        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)" />
+        <HeadingGroup
+          heading="Wildflower"
+          subheading="Wildflower (or wild flower)"
+          headingProps={{ size: "2xl" }}
+        />
       </Card.Header>
 
       <Card.Section divider="inset">
@@ -104,7 +116,11 @@ export const WithFooter = () => (
   <DocsWrapper>
     <Card>
       <Card.Header>
-        <HeadingGroup size="2xl" heading="Wildflower" subheading="Wildflower (or wild flower)" />
+        <HeadingGroup
+          heading="Wildflower"
+          subheading="Wildflower (or wild flower)"
+          headingProps={{ size: "2xl" }}
+        />
       </Card.Header>
 
       <Card.Section>
@@ -145,7 +161,7 @@ export const Spacings = () => (
   <DocsGridWrapper>
     <Card spacing="none">
       <Card.Header>
-        <HeadingGroup size="2xl" heading="none" subheading="No Spacing" />
+        <HeadingGroup heading="none" subheading="No Spacing" headingProps={{ size: "2xl" }} />
       </Card.Header>
 
       <br />
@@ -159,7 +175,7 @@ export const Spacings = () => (
 
     <Card spacing="sm">
       <Card.Header>
-        <HeadingGroup size="2xl" heading="sm" subheading="Small Spacing" />
+        <HeadingGroup heading="sm" subheading="Small Spacing" headingProps={{ size: "2xl" }} />
       </Card.Header>
 
       <Card.Section>
@@ -172,7 +188,11 @@ export const Spacings = () => (
 
     <Card spacing="md">
       <Card.Header>
-        <HeadingGroup size="2xl" heading="md" subheading="Medium (Default) Spacing" />
+        <HeadingGroup
+          heading="md"
+          subheading="Medium (Default) Spacing"
+          headingProps={{ size: "2xl" }}
+        />
       </Card.Header>
 
       <Card.Section>
@@ -185,7 +205,7 @@ export const Spacings = () => (
 
     <Card spacing="lg">
       <Card.Header>
-        <HeadingGroup size="2xl" heading="lg" subheading="Large Spacing" />
+        <HeadingGroup heading="lg" subheading="Large Spacing" headingProps={{ size: "2xl" }} />
       </Card.Header>
 
       <Card.Section>
@@ -198,7 +218,11 @@ export const Spacings = () => (
 
     <Card spacing="xl">
       <Card.Header>
-        <HeadingGroup size="2xl" heading="xl" subheading="Extra Large Spacing" />
+        <HeadingGroup
+          heading="xl"
+          subheading="Extra Large Spacing"
+          headingProps={{ size: "2xl" }}
+        />
       </Card.Header>
 
       <Card.Section>

--- a/src/navigation/__stories__/Tabs.stories.tsx
+++ b/src/navigation/__stories__/Tabs.stories.tsx
@@ -109,7 +109,7 @@ export const VerticalTabs = () => {
         <Card>
           <Card.Header>
             <HeadingGroup
-              size="2xl"
+              headingProps={{ size: "2xl" }}
               heading="Wildflower"
               subheading="Wildflower (or wild flower)"
             />
@@ -135,7 +135,7 @@ export const VerticalTabs = () => {
       <Tabs.TabPanel>
         <Card spacing="lg">
           <Card.Header>
-            <HeadingGroup size="2xl" heading="lg" subheading="Large Spacing" />
+            <HeadingGroup heading="lg" subheading="Large Spacing" headingProps={{ size: "2xl" }} />
           </Card.Header>
 
           <Card.Section>

--- a/src/text/HeadingGroup.tsx
+++ b/src/text/HeadingGroup.tsx
@@ -11,7 +11,7 @@ export interface HeadingGroupProps {
    * The heading level (1 through 6)
    * @default 2
    */
-  headingProps?: HeadingProps
+  headingProps?: Omit<HeadingProps, "children">
   /** Element ID */
   id?: string
   /** Additional class name for the whole group */

--- a/src/text/__stories__/HeadingGroup.stories.tsx
+++ b/src/text/__stories__/HeadingGroup.stories.tsx
@@ -26,17 +26,17 @@ const DocsWrapper = (props: React.PropsWithChildren) => {
 export const headingGroups = () => (
   <DocsWrapper>
     <HeadingGroup
-      size="3xl"
+      headingProps={{ size: "3xl" }}
       heading="Poppy"
       subheading="The tiny, kidney-shaped seeds have been harvested from dried seed pods by various civilizations for thousands of years."
     />
     <HeadingGroup
-      size="2xl"
+      headingProps={{ size: "2xl" }}
       heading="Sunflower"
       subheading="For commercial purposes, sunflower seeds are usually classified by the pattern on their husks."
     />
     <HeadingGroup
-      size="xl"
+      headingProps={{ size: "xl" }}
       heading="Pumpkin"
       subheading="Some  pumpkin cultivars are huskless, and are grown only for their edible seed."
     />

--- a/src/text/__stories__/Tag.stories.tsx
+++ b/src/text/__stories__/Tag.stories.tsx
@@ -28,7 +28,7 @@ const DocsIconWrapper = (props: React.PropsWithChildren) => {
 export const TagVariants = () => (
   <>
     <DocsWrapper>
-      <HeadingGroup size="2xl" heading="md" subheading="Regular Size" />
+      <HeadingGroup heading="md" subheading="Regular Size" headingProps={{ size: "2xl" }} />
       <div>
         <Tag variant="primary">Primary Tag</Tag>
         <Tag variant="secondary">Secondary Tag</Tag>
@@ -47,7 +47,7 @@ export const TagVariants = () => (
       </div>
     </DocsWrapper>
     <DocsWrapper>
-      <HeadingGroup size="2xl" heading="lg" subheading="Large Size" />
+      <HeadingGroup heading="lg" subheading="Large Size" headingProps={{ size: "2xl" }} />
       <div>
         <Tag variant="primary" size="lg">
           Primary Tag


### PR DESCRIPTION
## Issue Overview

This PR addresses [#4913](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4913)

## Description

It's build issue fix to align storybook with new headingProps

## How Can This Be Tested/Reviewed?

Run storybook. 
`Button.stories`
`Card.stories`
`Tabs.stories`
`HeadingGroup.stories`
`Tag.stories`
should display headingGroup correctly.
And it should not require `children` prop

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
