### PR TITLE
fix: allow disabling live for loading state

### DIFF
--- a/src/blocks/LoadingState.tsx
+++ b/src/blocks/LoadingState.tsx
@@ -10,7 +10,7 @@ interface LoadingStateProps {
   id?: string
   /** Additional CSS classes */
   className?: string
-  /** Disable aria-live attribute for screen readers */
+  /** Disable aria-live attribute for screen readers - if you set this to true, screen readers will not be automatically notified of loading state changes in this content, so ensure you provide intentional alternative feedback */
   disableAriaLive?: boolean
 }
 

--- a/src/blocks/LoadingState.tsx
+++ b/src/blocks/LoadingState.tsx
@@ -10,14 +10,21 @@ interface LoadingStateProps {
   id?: string
   /** Additional CSS classes */
   className?: string
+  /** Disable aria-live attribute for screen readers */
+  disableAriaLive?: boolean
 }
 
-const LoadingState = ({ loading, children, id, className }: LoadingStateProps) => {
+const LoadingState = ({ loading, children, id, className, disableAriaLive }: LoadingStateProps) => {
   const classNames = ["seeds-loading-state"]
   if (className) classNames.push(className)
 
   return (
-    <div id={id} className={classNames.join(" ")} aria-live="polite" aria-busy={loading}>
+    <div
+      id={id}
+      className={classNames.join(" ")}
+      aria-live={disableAriaLive ? undefined : "polite"}
+      aria-busy={loading}
+    >
       {loading ? <div className="loading-state-spinner"></div> : <>{children}</>}
     </div>
   )


### PR DESCRIPTION
## Description

For the most part, having aria-live=polite on the loading content is desired. However, sometimes it's preferable to have a different piece of content be what is announced when the content loads (like: `10 results found`) instead of immediately reading the content. This PR will allow us to selectively turn aria-live=polite off on the loading state. We will not use this often, but will pull this into the housing advocate my applications search page.

## How Can This Be Tested/Reviewed?

I added a comment to ensure consumers understand if it is disabled they have the responsibility to set up an alternative accessible path to alerting users about loaded content.

## Checklist:

- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have exported any new components
- [ ] My commit message(s) and PR title are polished in the conventional commit format, and any breaking changes are indicated in the message and are well-described
